### PR TITLE
Refactor: consolidate fit pipeline; extract FitDriver, ParameterVector, InnovationSpec

### DIFF
--- a/include/ag/api/Engine.hpp
+++ b/include/ag/api/Engine.hpp
@@ -179,13 +179,6 @@ public:
              bool use_student_t = false, double student_t_df = 2.0);
 
 private:
-    // Configuration parameters for optimization
-    static constexpr double OPTIMIZER_FTOL = 1e-6;
-    static constexpr double OPTIMIZER_XTOL = 1e-6;
-    static constexpr int OPTIMIZER_MAX_ITER = 2000;
-    static constexpr int NUM_RESTARTS = 3;
-    static constexpr double PERTURBATION_SCALE = 0.15;
-
     /**
      * @brief Validate Student-t degrees of freedom parameter.
      * @param df Degrees of freedom to validate
@@ -198,26 +191,6 @@ private:
         }
         return "";
     }
-
-    /**
-     * @brief Helper to pack ARIMA-GARCH parameters into a vector.
-     * @param arima_params ARIMA parameters
-     * @param garch_params GARCH parameters
-     * @return Vector of packed parameters
-     */
-    std::vector<double> packParameters(const models::arima::ArimaParameters& arima_params,
-                                       const models::garch::GarchParameters& garch_params) const;
-
-    /**
-     * @brief Helper to unpack vector into ARIMA-GARCH parameters.
-     * @param params Parameter vector
-     * @param spec Model specification
-     * @param out_arima Output ARIMA parameters
-     * @param out_garch Output GARCH parameters
-     */
-    void unpackParameters(const std::vector<double>& params, const models::ArimaGarchSpec& spec,
-                          models::arima::ArimaParameters& out_arima,
-                          models::garch::GarchParameters& out_garch) const;
 };
 
 }  // namespace ag::api

--- a/include/ag/estimation/FitDriver.hpp
+++ b/include/ag/estimation/FitDriver.hpp
@@ -44,10 +44,14 @@ struct FitOutcome {
  * violations and for likelihood-computation exceptions, exactly matching
  * the prior behavior.
  *
- * Returns std::nullopt only when parameter initialization itself throws
- * (e.g. insufficient data); convergence/non-convergence is reported via
- * FitOutcome::converged so callers can decide whether to accept the
- * result.
+ * Returns std::nullopt only when data is null or empty (a programming
+ * error that should have been caught by the caller). All other failure
+ * modes — parameter initialization exceptions (e.g. insufficient data
+ * after differencing), likelihood evaluation failures in the no-free-
+ * parameters path, optimizer exceptions, and parameter-unpack failures —
+ * are reported as FitOutcome{converged=false, message=<reason>} so callers
+ * receive actionable diagnostics. Successful convergence is indicated by
+ * FitOutcome{converged=true}.
  */
 [[nodiscard]] std::optional<FitOutcome> runFit(const double* data, std::size_t n,
                                                const ag::models::ArimaGarchSpec& spec,

--- a/include/ag/estimation/FitDriver.hpp
+++ b/include/ag/estimation/FitDriver.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "ag/estimation/InnovationSpec.hpp"
+#include "ag/estimation/Optimizer.hpp"
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/models/composite/ArimaGarchModel.hpp"
+
+#include <cstddef>
+#include <optional>
+#include <string>
+
+namespace ag::estimation {
+
+/**
+ * @brief Options bundle for runFit.
+ */
+struct FitOptions {
+    InnovationSpec innovation = InnovationSpec::normal();
+    OptimizerConfig optimizer{};
+};
+
+/**
+ * @brief Output of runFit. Mirrors the relevant fields of
+ *        OptimizationResult plus the unpacked parameter structs.
+ */
+struct FitOutcome {
+    ag::models::composite::ArimaGarchParameters parameters;
+    double neg_log_likelihood = 0.0;
+    bool converged = false;
+    int iterations = 0;
+    std::string message;
+
+    explicit FitOutcome(const ag::models::ArimaGarchSpec& spec) : parameters(spec) {}
+};
+
+/**
+ * @brief Single canonical implementation of the ARIMA-GARCH fit pipeline:
+ *        initialize parameters -> pack -> Nelder-Mead with restarts ->
+ *        unpack -> return.
+ *
+ * Replaces four previous copies of this exact loop in Engine,
+ * ModelSelector (two branches), and CrossValidation. The objective
+ * function applies CONSTRAINT_PENALTY for GARCH positivity / stationarity
+ * violations and for likelihood-computation exceptions, exactly matching
+ * the prior behavior.
+ *
+ * Returns std::nullopt only when parameter initialization itself throws
+ * (e.g. insufficient data); convergence/non-convergence is reported via
+ * FitOutcome::converged so callers can decide whether to accept the
+ * result.
+ */
+[[nodiscard]] std::optional<FitOutcome> runFit(const double* data, std::size_t n,
+                                               const ag::models::ArimaGarchSpec& spec,
+                                               const FitOptions& options = {});
+
+}  // namespace ag::estimation

--- a/include/ag/estimation/InnovationSpec.hpp
+++ b/include/ag/estimation/InnovationSpec.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace ag::estimation {
+
+/**
+ * @brief Innovation distribution type for likelihood and simulation.
+ *
+ * Kept as the canonical enumeration. The simulation namespace exposes an
+ * alias so legacy call sites continue to compile.
+ */
+enum class InnovationDistribution {
+    Normal,   // Standard normal N(0,1)
+    StudentT  // Standardized Student-t with df degrees of freedom
+};
+
+/**
+ * @brief Value type bundling an innovation distribution with its
+ *        distribution-specific parameters.
+ *
+ * Replaces the unstructured (bool use_student_t, double df) parameter pair
+ * that previously appeared in fit, simulate, and diagnostics call sites.
+ * The invariant "df is only meaningful for StudentT" is encoded by
+ * construction: the factory functions are the only well-formed entry
+ * points, and ::studentT validates df >= 2.0001 up-front (any value <=2
+ * yields infinite variance for the standardized Student-t parameterization
+ * used here).
+ */
+struct InnovationSpec {
+    InnovationDistribution type = InnovationDistribution::Normal;
+    double df = 0.0;  // Only meaningful when type == StudentT.
+
+    [[nodiscard]] static InnovationSpec normal() noexcept {
+        return InnovationSpec{InnovationDistribution::Normal, 0.0};
+    }
+
+    [[nodiscard]] static InnovationSpec studentT(double df) {
+        if (!(df > 2.0)) {
+            throw std::invalid_argument(
+                "InnovationSpec::studentT: degrees of freedom must be > 2.0, got " +
+                std::to_string(df));
+        }
+        return InnovationSpec{InnovationDistribution::StudentT, df};
+    }
+
+    [[nodiscard]] bool isStudentT() const noexcept {
+        return type == InnovationDistribution::StudentT;
+    }
+};
+
+}  // namespace ag::estimation

--- a/include/ag/estimation/Likelihood.hpp
+++ b/include/ag/estimation/Likelihood.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ag/estimation/InnovationSpec.hpp"
 #include "ag/models/ArimaGarchSpec.hpp"
 #include "ag/models/arima/ArimaModel.hpp"
 #include "ag/models/garch/GarchModel.hpp"
@@ -9,13 +10,9 @@
 
 namespace ag::estimation {
 
-/**
- * @brief Innovation distribution type for likelihood estimation.
- */
-enum class InnovationDistribution {
-    Normal,   // Standard normal N(0,1)
-    StudentT  // Standardized Student-t with specified degrees of freedom
-};
+// InnovationDistribution is defined in InnovationSpec.hpp; included here
+// so existing call sites that reach for it through Likelihood.hpp still
+// compile.
 
 /**
  * @brief Likelihood computation for ARIMA-GARCH models with Normal or Student-t innovations.
@@ -89,25 +86,6 @@ public:
     [[nodiscard]] InnovationDistribution getDistribution() const noexcept { return dist_; }
 
 private:
-    /**
-     * @brief Compute log-likelihood contribution for a single Student-t innovation.
-     *
-     * Computes the log-likelihood for a standardized residual under Student-t distribution:
-     *   log L = log(Γ((df+1)/2)) - log(Γ(df/2)) - 0.5*log(π*(df-2)*h_t)
-     *           - 0.5*(df+1)*log(1 + z_t²)
-     * where z_t = ε_t / sqrt((df-2)*h_t) is the standardized residual
-     *
-     * The negative log-likelihood contribution is:
-     *   -log L = -log(Γ((df+1)/2)) + log(Γ(df/2)) + 0.5*log(π*(df-2)*h_t)
-     *            + 0.5*(df+1)*log(1 + ε_t²/((df-2)*h_t))
-     *
-     * @param residual ARIMA residual ε_t
-     * @param variance Conditional variance h_t
-     * @param df Degrees of freedom (must be > 2)
-     * @return Negative log-likelihood contribution for this observation
-     */
-    [[nodiscard]] double studentTLogLikelihood(double residual, double variance, double df) const;
-
     ag::models::ArimaGarchSpec spec_;      // Model specification
     InnovationDistribution dist_;          // Innovation distribution type
     ag::models::arima::ArimaModel arima_;  // ARIMA model for residuals

--- a/include/ag/estimation/Optimizer.hpp
+++ b/include/ag/estimation/Optimizer.hpp
@@ -8,6 +8,32 @@
 namespace ag::estimation {
 
 /**
+ * @brief Penalty value returned by likelihood objective functions when the
+ *        proposed parameters violate model constraints (e.g. GARCH positivity
+ *        or stationarity). Large enough that the optimizer reliably moves
+ *        away from infeasible regions, finite to avoid corrupting simplex
+ *        arithmetic.
+ */
+inline constexpr double CONSTRAINT_PENALTY = 1e10;
+
+/**
+ * @brief Bundled configuration for the Nelder-Mead fit pipeline.
+ *
+ * Mirrors the production tuning previously hard-coded at multiple call
+ * sites (Engine, ModelSelector, CrossValidation). The defaults match the
+ * actually-used values; the IOptimizer DEFAULT_FTOL/XTOL constants are
+ * tighter (1e-8) and remain available for callers that want them.
+ */
+struct OptimizerConfig {
+    double ftol = 1e-6;                // Function value tolerance
+    double xtol = 1e-6;                // Parameter tolerance
+    int max_iterations = 2000;         // Hard cap on iterations per restart
+    int restarts = 3;                  // Additional perturbed restarts (0 = single run)
+    double perturbation_scale = 0.15;  // Std-dev of normal perturbation per parameter
+    unsigned int seed = 42;            // RNG seed for perturbations; 0 = nondeterministic
+};
+
+/**
  * @brief Result of an optimization run.
  *
  * OptimizationResult contains the optimal parameters found by the optimizer,
@@ -247,6 +273,16 @@ private:
      */
     void shrink(std::vector<std::vector<double>>& simplex,
                 const std::vector<double>& best_point) const;
+
+    /**
+     * @brief Advance a sorted simplex by one Nelder-Mead step
+     *        (reflection / expansion / contraction / shrink). The simplex
+     *        and corresponding objective values are updated in place.
+     *
+     * Precondition: @p simplex is sorted ascending by @p simplex_values.
+     */
+    void stepSimplex(std::vector<std::vector<double>>& simplex, std::vector<double>& simplex_values,
+                     const ObjectiveFunction& objective) const;
 };
 
 /**

--- a/include/ag/estimation/ParameterVector.hpp
+++ b/include/ag/estimation/ParameterVector.hpp
@@ -19,9 +19,12 @@ namespace ag::estimation {
  * mismatch existed: Engine packed the ARIMA intercept unconditionally
  * while ModelSelector and CrossValidation skipped the ARIMA block
  * entirely for zero-order specs. The Selector convention is adopted here
- * (skip the ARIMA block when spec.arimaSpec.isZeroOrder()): the
- * intercept and AR/MA arrays are degenerate at p=q=0 and would only add
- * a useless optimization dimension.
+ * (skip the ARIMA block when spec.arimaSpec.isZeroOrder()): for a
+ * zero-order ARIMA spec the intercept is intentionally fixed at zero
+ * rather than estimated. With no AR or MA structure to anchor it, adding
+ * the intercept as a free optimization parameter would provide no
+ * useful information. Callers that need a non-zero constant mean should
+ * difference the data or use a non-zero-order ARIMA spec.
  *
  * Layout (when present, in order):
  *   - intercept (if !arimaSpec.isZeroOrder())

--- a/include/ag/estimation/ParameterVector.hpp
+++ b/include/ag/estimation/ParameterVector.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/models/arima/ArimaModel.hpp"
+#include "ag/models/garch/GarchModel.hpp"
+
+#include <cstddef>
+#include <vector>
+
+namespace ag::estimation {
+
+/**
+ * @brief Pack/unpack ARIMA-GARCH parameters into the flat std::vector<double>
+ *        layout consumed by the optimizer.
+ *
+ * Single source of truth for the convention used between Engine,
+ * ModelSelector, CrossValidation, and FitDriver. Previously these sites
+ * each had inline copies of the same loop, and a subtle convention
+ * mismatch existed: Engine packed the ARIMA intercept unconditionally
+ * while ModelSelector and CrossValidation skipped the ARIMA block
+ * entirely for zero-order specs. The Selector convention is adopted here
+ * (skip the ARIMA block when spec.arimaSpec.isZeroOrder()): the
+ * intercept and AR/MA arrays are degenerate at p=q=0 and would only add
+ * a useless optimization dimension.
+ *
+ * Layout (when present, in order):
+ *   - intercept (if !arimaSpec.isZeroOrder())
+ *   - p AR coefficients
+ *   - q MA coefficients
+ *   - omega (if !garchSpec.isNull())
+ *   - q ARCH (alpha) coefficients
+ *   - p GARCH (beta) coefficients
+ */
+namespace param_vector {
+
+/**
+ * @brief Compute the optimization vector length for a given spec.
+ */
+[[nodiscard]] std::size_t size(const ag::models::ArimaGarchSpec& spec) noexcept;
+
+/**
+ * @brief Pack initial ARIMA + GARCH parameters into the flat vector.
+ */
+[[nodiscard]] std::vector<double> pack(const ag::models::ArimaGarchSpec& spec,
+                                       const ag::models::arima::ArimaParameters& arima_params,
+                                       const ag::models::garch::GarchParameters& garch_params);
+
+/**
+ * @brief Unpack a flat parameter vector back into typed structs.
+ *
+ * out_arima and out_garch must already be sized for the spec (use the
+ * ArimaParameters/GarchParameters constructors that take p/q). Throws
+ * std::invalid_argument if params.size() != size(spec).
+ */
+void unpack(const std::vector<double>& params, const ag::models::ArimaGarchSpec& spec,
+            ag::models::arima::ArimaParameters& out_arima,
+            ag::models::garch::GarchParameters& out_garch);
+
+}  // namespace param_vector
+
+}  // namespace ag::estimation

--- a/include/ag/models/arima/ArimaModel.hpp
+++ b/include/ag/models/arima/ArimaModel.hpp
@@ -67,19 +67,13 @@ public:
                                                        const ArimaParameters& params) const;
 
     /**
-     * @brief Get the ARIMA specification for this model.
-     * @return The ARIMA(p,d,q) specification
-     */
-    [[nodiscard]] const ag::models::ArimaSpec& getSpec() const noexcept { return spec_; }
-
-private:
-    ag::models::ArimaSpec spec_;  // ARIMA(p,d,q) specification
-
-    /**
      * @brief Compute the conditional mean for a single observation.
      *
      * Calculates the expected value based on the ARIMA model equation:
      * E[y_t] = c + φ₁*y_{t-1} + ... + φₚ*y_{t-p} + θ₁*ε_{t-1} + ... + θ_q*ε_{t-q}
+     *
+     * Exposed so the composite ARIMA-GARCH model can share this recursion
+     * step without reimplementing it.
      *
      * @param state Current state containing historical observations and residuals
      * @param params Model parameters
@@ -87,6 +81,15 @@ private:
      */
     [[nodiscard]] double computeConditionalMean(const ArimaState& state,
                                                 const ArimaParameters& params) const;
+
+    /**
+     * @brief Get the ARIMA specification for this model.
+     * @return The ARIMA(p,d,q) specification
+     */
+    [[nodiscard]] const ag::models::ArimaSpec& getSpec() const noexcept { return spec_; }
+
+private:
+    ag::models::ArimaSpec spec_;  // ARIMA(p,d,q) specification
 };
 
 }  // namespace ag::models::arima

--- a/include/ag/models/garch/GarchModel.hpp
+++ b/include/ag/models/garch/GarchModel.hpp
@@ -101,19 +101,15 @@ public:
                                 const GarchParameters& params) const;
 
     /**
-     * @brief Get the GARCH specification for this model.
-     * @return The GARCH(p,q) specification
-     */
-    [[nodiscard]] const ag::models::GarchSpec& getSpec() const noexcept { return spec_; }
-
-private:
-    ag::models::GarchSpec spec_;  // GARCH(p,q) specification
-
-    /**
      * @brief Compute the conditional variance for a single observation.
      *
      * Calculates the conditional variance based on the GARCH model equation:
      * h_t = ω + α₁*ε²_{t-1} + ... + α_q*ε²_{t-q} + β₁*h_{t-1} + ... + βₚ*h_{t-p}
+     *
+     * Exposed so the composite ARIMA-GARCH model and the simulator can
+     * share this recursion step without reimplementing it. The raw
+     * recursion is returned; callers that need positivity floors should
+     * apply ag::util::MIN_VARIANCE.
      *
      * @param state Current state containing historical variances and squared residuals
      * @param params Model parameters
@@ -121,6 +117,15 @@ private:
      */
     [[nodiscard]] double computeConditionalVariance(const GarchState& state,
                                                     const GarchParameters& params) const;
+
+    /**
+     * @brief Get the GARCH specification for this model.
+     * @return The GARCH(p,q) specification
+     */
+    [[nodiscard]] const ag::models::GarchSpec& getSpec() const noexcept { return spec_; }
+
+private:
+    ag::models::GarchSpec spec_;  // GARCH(p,q) specification
 };
 
 }  // namespace ag::models::garch

--- a/include/ag/simulation/ArimaGarchSimulator.hpp
+++ b/include/ag/simulation/ArimaGarchSimulator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ag/estimation/InnovationSpec.hpp"
 #include "ag/models/composite/ArimaGarchModel.hpp"
 #include "ag/simulation/Innovations.hpp"
 
@@ -8,13 +9,11 @@
 
 namespace ag::simulation {
 
-/**
- * @brief Innovation distribution type for simulation.
- */
-enum class InnovationDistribution {
-    Normal,   // Standard normal N(0,1)
-    StudentT  // Standardized Student-t with specified degrees of freedom
-};
+// Re-export the canonical estimation::InnovationDistribution into the
+// simulation namespace so legacy call sites (Engine, examples, CLI)
+// continue to resolve ag::simulation::InnovationDistribution::Normal /
+// ::StudentT without modification.
+using InnovationDistribution = ag::estimation::InnovationDistribution;
 
 /**
  * @brief Result of an ARIMA-GARCH simulation.

--- a/include/ag/util/Differencing.hpp
+++ b/include/ag/util/Differencing.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace ag::util {
+
+/**
+ * @brief Apply d-th order discrete differencing to a contiguous data buffer.
+ *
+ * First-differencing computes y'_t = y_t - y_{t-1}; the operation is
+ * applied d times in sequence, shortening the series by d observations.
+ * Used in two places: ARIMA state initialization and parameter
+ * initialization heuristics — both need to operate on the same
+ * differenced view of the data.
+ *
+ * @param data Pointer to the input series (may be null only if size == 0).
+ * @param size Number of observations in the input series.
+ * @param d   Order of differencing (must be >= 0).
+ * @return Differenced series of length max(0, size - d). For d == 0,
+ *         returns a copy of the input series. If d exceeds size - 1,
+ *         returns an empty vector rather than throwing.
+ */
+[[nodiscard]] std::vector<double> differenceSeries(const double* data, std::size_t size, int d);
+
+}  // namespace ag::util

--- a/include/ag/util/NumericConstants.hpp
+++ b/include/ag/util/NumericConstants.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace ag::util {
+
+// Lower bound applied to GARCH conditional variances to guard against
+// numerical underflow during recursion. Positivity of h_t is enforced
+// upstream by parameter constraints; this is purely a numerical floor.
+inline constexpr double MIN_VARIANCE = 1e-10;
+
+}  // namespace ag::util

--- a/include/ag/util/SlidingWindow.hpp
+++ b/include/ag/util/SlidingWindow.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+namespace ag::util {
+
+/**
+ * @brief Shift the elements of buf left by one and write @p value into the
+ *        last slot.
+ *
+ * Used by ARIMA and GARCH state classes to maintain bounded-history buffers
+ * during recursion. No-op on empty buffers.
+ */
+template <typename T>
+void shiftAndAppend(std::vector<T>& buf, const T& value) {
+    if (buf.empty()) {
+        return;
+    }
+    std::shift_left(buf.begin(), buf.end(), 1);
+    buf.back() = value;
+}
+
+}  // namespace ag::util

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,10 +6,12 @@ add_library(arimagarch STATIC
     diagnostics/DiagnosticReport.cpp
     diagnostics/Residuals.cpp
     estimation/Constraints.cpp
+    estimation/FitDriver.cpp
     estimation/Likelihood.cpp
     estimation/NumericalDerivatives.cpp
     estimation/Optimizer.cpp
     estimation/ParameterInitialization.cpp
+    estimation/ParameterVector.cpp
     forecasting/Forecaster.cpp
     io/CsvReader.cpp
     io/CsvWriter.cpp
@@ -34,6 +36,7 @@ add_library(arimagarch STATIC
     stats/JarqueBera.cpp
     stats/LjungBox.cpp
     stats/PACF.cpp
+    util/Differencing.cpp
     util/LinearAlgebra.cpp
     util/Logging.cpp
     util/Timer.cpp
@@ -50,8 +53,15 @@ target_link_libraries(arimagarch PUBLIC fmt::fmt nlohmann_json::nlohmann_json)
 add_executable(ag
     cli/main.cpp
     cli/CliUtils.cpp
+    cli/handlers/DiagnosticsHandler.cpp
+    cli/handlers/FitHandler.cpp
+    cli/handlers/ForecastHandler.cpp
+    cli/handlers/SelectHandler.cpp
+    cli/handlers/SimulateFromModelHandler.cpp
+    cli/handlers/SimulateHandler.cpp
 )
 
+target_include_directories(ag PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cli)
 target_link_libraries(ag PRIVATE arimagarch CLI11::CLI11)
 
 # Stage `ag` under examples/terminal/bin so the terminal example scripts find

--- a/src/api/Engine.cpp
+++ b/src/api/Engine.cpp
@@ -46,7 +46,7 @@ expected<FitResult, EngineError> Engine::fit(const std::vector<double>& data,
         auto fit_outcome = estimation::runFit(data.data(), data.size(), spec, options);
         if (!fit_outcome) {
             return unexpected<EngineError>(
-                {"Optimization failed: parameter initialization or fit pipeline error"});
+                {"Optimization failed: null or empty data passed to fit pipeline"});
         }
         if (!fit_outcome->converged) {
             return unexpected<EngineError>(

--- a/src/api/Engine.cpp
+++ b/src/api/Engine.cpp
@@ -1,9 +1,8 @@
 #include "ag/api/Engine.hpp"
 
 #include "ag/diagnostics/DiagnosticReport.hpp"
-#include "ag/estimation/Likelihood.hpp"
-#include "ag/estimation/Optimizer.hpp"
-#include "ag/estimation/ParameterInitialization.hpp"
+#include "ag/estimation/FitDriver.hpp"
+#include "ag/estimation/InnovationSpec.hpp"
 #include "ag/selection/DistributionSelector.hpp"
 #include "ag/selection/InformationCriteria.hpp"
 
@@ -39,78 +38,37 @@ expected<FitResult, EngineError> Engine::fit(const std::vector<double>& data,
     }
 
     try {
-        // Step 1: Initialize parameters
-        auto [arima_init, garch_init] =
-            estimation::initializeArimaGarchParameters(data.data(), data.size(), spec);
+        estimation::FitOptions options;
+        options.innovation = use_student_t ? estimation::InnovationSpec::studentT(student_t_df)
+                                           : estimation::InnovationSpec::normal();
+        options.optimizer.seed = 0;  // Engine historically used a nondeterministic seed.
 
-        // Step 2: Build likelihood function with specified distribution
-        estimation::InnovationDistribution dist = use_student_t
-                                                      ? estimation::InnovationDistribution::StudentT
-                                                      : estimation::InnovationDistribution::Normal;
-        estimation::ArimaGarchLikelihood likelihood(spec, dist);
-
-        // Step 3: Pack initial parameters
-        std::vector<double> initial_params = packParameters(arima_init, garch_init);
-
-        // Step 4: Define objective function with constraint checking
-        auto objective = [&](const std::vector<double>& params) -> double {
-            models::arima::ArimaParameters arima_p(spec.arimaSpec.p, spec.arimaSpec.q);
-            models::garch::GarchParameters garch_p(spec.garchSpec.p, spec.garchSpec.q);
-
-            unpackParameters(params, spec, arima_p, garch_p);
-
-            // Check GARCH constraints (skip if ARIMA-only model)
-            if (!spec.garchSpec.isNull()) {
-                if (!garch_p.isPositive() || !garch_p.isStationary()) {
-                    return 1e10;  // Penalty for constraint violation
-                }
-            }
-
-            try {
-                return likelihood.computeNegativeLogLikelihood(data.data(), data.size(), arima_p,
-                                                               garch_p, student_t_df);
-            } catch (...) {
-                return 1e10;  // Penalty for evaluation failure
-            }
-        };
-
-        // Step 5: Run optimization with random restarts
-        estimation::NelderMeadOptimizer optimizer(OPTIMIZER_FTOL, OPTIMIZER_XTOL,
-                                                  OPTIMIZER_MAX_ITER);
-        auto opt_result = estimation::optimizeWithRestarts(optimizer, objective, initial_params,
-                                                           NUM_RESTARTS, PERTURBATION_SCALE, 0);
-
-        if (!opt_result.converged) {
+        auto fit_outcome = estimation::runFit(data.data(), data.size(), spec, options);
+        if (!fit_outcome) {
             return unexpected<EngineError>(
-                {"Optimization failed to converge: " + opt_result.message});
+                {"Optimization failed: parameter initialization or fit pipeline error"});
+        }
+        if (!fit_outcome->converged) {
+            return unexpected<EngineError>(
+                {"Optimization failed to converge: " + fit_outcome->message});
         }
 
-        // Step 6: Unpack optimized parameters
-        models::arima::ArimaParameters arima_params(spec.arimaSpec.p, spec.arimaSpec.q);
-        models::garch::GarchParameters garch_params(spec.garchSpec.p, spec.garchSpec.q);
-        unpackParameters(opt_result.parameters, spec, arima_params, garch_params);
-
-        // Step 7: Build the fitted model
-        models::composite::ArimaGarchParameters model_params(spec);
-        model_params.arima_params = arima_params;
-        model_params.garch_params = garch_params;
-
+        // Build the fitted model from the converged parameters.
+        models::composite::ArimaGarchParameters model_params = fit_outcome->parameters;
         auto fitted_model =
             std::make_shared<models::composite::ArimaGarchModel>(spec, model_params);
 
-        // Initialize model state with data
         for (const auto& value : data) {
             fitted_model->update(value);
         }
 
-        // Step 8: Create FitSummary
         report::FitSummary summary(spec);
         summary.parameters = model_params;
-        summary.converged = opt_result.converged;
-        summary.iterations = opt_result.iterations;
-        summary.message = opt_result.message;
+        summary.converged = fit_outcome->converged;
+        summary.iterations = fit_outcome->iterations;
+        summary.message = fit_outcome->message;
         summary.sample_size = data.size();
-        summary.neg_log_likelihood = opt_result.objective_value;
+        summary.neg_log_likelihood = fit_outcome->neg_log_likelihood;
         summary.innovation_distribution = use_student_t ? "Student-t" : "Normal";
         summary.student_t_df = use_student_t ? student_t_df : 0.0;
 
@@ -120,7 +78,7 @@ expected<FitResult, EngineError> Engine::fit(const std::vector<double>& data,
         // Note: df parameter is user-provided, not estimated, so we don't count it in k
         std::size_t k = spec.totalParamCount();
         std::size_t n = data.size();
-        double log_lik = -opt_result.objective_value;  // Convert NLL to log-likelihood
+        double log_lik = -fit_outcome->neg_log_likelihood;  // Convert NLL to log-likelihood
         summary.aic = selection::computeAIC(log_lik, k);
         summary.bic = selection::computeBIC(log_lik, k, n);
 
@@ -266,60 +224,6 @@ Engine::simulate(const models::ArimaGarchSpec& spec,
         return sim_result;
     } catch (const std::exception& e) {
         return unexpected<EngineError>({"Simulation failed: " + std::string(e.what())});
-    }
-}
-
-std::vector<double>
-Engine::packParameters(const models::arima::ArimaParameters& arima_params,
-                       const models::garch::GarchParameters& garch_params) const {
-    std::vector<double> params;
-
-    // Pack ARIMA parameters
-    params.push_back(arima_params.intercept);
-    for (const auto& ar : arima_params.ar_coef) {
-        params.push_back(ar);
-    }
-    for (const auto& ma : arima_params.ma_coef) {
-        params.push_back(ma);
-    }
-
-    // Pack GARCH parameters (skip if null GARCH)
-    if (!garch_params.alpha_coef.empty() || !garch_params.beta_coef.empty()) {
-        params.push_back(garch_params.omega);
-        for (const auto& alpha : garch_params.alpha_coef) {
-            params.push_back(alpha);
-        }
-        for (const auto& beta : garch_params.beta_coef) {
-            params.push_back(beta);
-        }
-    }
-
-    return params;
-}
-
-void Engine::unpackParameters(const std::vector<double>& params, const models::ArimaGarchSpec& spec,
-                              models::arima::ArimaParameters& out_arima,
-                              models::garch::GarchParameters& out_garch) const {
-    std::size_t idx = 0;
-
-    // Unpack ARIMA parameters
-    out_arima.intercept = params[idx++];
-    for (std::size_t i = 0; i < spec.arimaSpec.p; ++i) {
-        out_arima.ar_coef[i] = params[idx++];
-    }
-    for (std::size_t i = 0; i < spec.arimaSpec.q; ++i) {
-        out_arima.ma_coef[i] = params[idx++];
-    }
-
-    // Unpack GARCH parameters (skip if null GARCH)
-    if (!spec.garchSpec.isNull()) {
-        out_garch.omega = params[idx++];
-        for (std::size_t i = 0; i < spec.garchSpec.q; ++i) {
-            out_garch.alpha_coef[i] = params[idx++];
-        }
-        for (std::size_t i = 0; i < spec.garchSpec.p; ++i) {
-            out_garch.beta_coef[i] = params[idx++];
-        }
     }
 }
 

--- a/src/cli/Handlers.hpp
+++ b/src/cli/Handlers.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+// Subcommand handler declarations for the `ag` CLI. Each function returns
+// a process exit code (0 = success, non-zero = error).
+
+#include <exception>
+#include <string>
+
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+/**
+ * @brief Run a callable, mapping any std::exception it throws to exit code 1
+ *        with the exception message printed to stdout. Shared by every CLI
+ *        handler so error formatting stays uniform.
+ */
+template <typename Func>
+int executeWithErrorHandling(Func&& func) {
+    try {
+        return func();
+    } catch (const std::exception& e) {
+        fmt::print("Error: {}\n", e.what());
+        return 1;
+    }
+}
+
+int handleFit(const std::string& dataFile, const std::string& arimaOrder,
+              const std::string& garchOrder, const std::string& outputFile, bool no_header,
+              bool use_student_t, double student_t_df);
+
+int handleSelect(const std::string& dataFile, int maxP, int maxD, int maxQ, int maxGarchP,
+                 int maxGarchQ, const std::string& criterion, const std::string& outputFile,
+                 int topK, bool no_header);
+
+int handleForecast(const std::string& modelFile, int horizon, const std::string& outputFile);
+
+int handleSimulate(const std::string& arimaOrder, const std::string& garchOrder, int length,
+                   unsigned int seed, const std::string& outputFile, bool use_student_t,
+                   double student_t_df);
+
+int handleSimulateFromModel(const std::string& modelFile, int numPaths, int length,
+                            unsigned int seed, const std::string& outputFile, bool computeStats);
+
+int handleDiagnostics(const std::string& modelFile, const std::string& dataFile,
+                      const std::string& outputFile, bool no_header);
+
+}  // namespace ag::cli

--- a/src/cli/handlers/DiagnosticsHandler.cpp
+++ b/src/cli/handlers/DiagnosticsHandler.cpp
@@ -1,0 +1,110 @@
+#include "ag/cli/CliUtils.hpp"
+#include "ag/diagnostics/DiagnosticReport.hpp"
+#include "ag/io/Json.hpp"
+#include "ag/models/composite/ArimaGarchModel.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <fstream>
+#include <string>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+#include <nlohmann/json.hpp>
+
+namespace ag::cli {
+
+int handleDiagnostics(const std::string& modelFile, const std::string& dataFile,
+                      const std::string& outputFile, bool no_header) {
+    return executeWithErrorHandling([&]() {
+        fmt::print("Loading model from {}...\n", modelFile);
+        auto model_result = ag::io::JsonReader::loadModel(modelFile);
+        if (!model_result) {
+            fmt::print("Error: Failed to load model from {}\n", modelFile);
+            return 1;
+        }
+
+        fmt::print("Loading data from {}...\n", dataFile);
+        auto data = loadData(dataFile, !no_header);
+        fmt::print("Loaded {} observations\n", data.size());
+
+        fmt::print("Running diagnostic tests...\n");
+
+        auto& model = *model_result;
+        const std::size_t ljung_box_lags = std::min(static_cast<std::size_t>(10), data.size() / 5);
+
+        ag::models::composite::ArimaGarchParameters params(model.getSpec());
+        params.arima_params = model.getArimaParams();
+        params.garch_params = model.getGarchParams();
+
+        auto diagnostics = ag::diagnostics::computeDiagnostics(model.getSpec(), params, data,
+                                                               ljung_box_lags, true);
+
+        fmt::print("✅ Diagnostics completed\n\n");
+        fmt::print("=== Diagnostic Tests ===\n\n");
+
+        fmt::print("Ljung-Box Test (raw residuals):\n");
+        fmt::print("  Statistic: {:.4f}\n", diagnostics.ljung_box_residuals.statistic);
+        fmt::print("  P-value: {:.4f}\n", diagnostics.ljung_box_residuals.p_value);
+        fmt::print("  DOF: {}\n", diagnostics.ljung_box_residuals.dof);
+        fmt::print("  Lags: {}\n\n", diagnostics.ljung_box_residuals.lags);
+
+        fmt::print("Ljung-Box Test (squared residuals):\n");
+        fmt::print("  Statistic: {:.4f}\n", diagnostics.ljung_box_squared.statistic);
+        fmt::print("  P-value: {:.4f}\n", diagnostics.ljung_box_squared.p_value);
+        fmt::print("  DOF: {}\n", diagnostics.ljung_box_squared.dof);
+        fmt::print("  Lags: {}\n\n", diagnostics.ljung_box_squared.lags);
+
+        fmt::print("Jarque-Bera Test:\n");
+        fmt::print("  Statistic: {:.4f}\n", diagnostics.jarque_bera.statistic);
+        fmt::print("  P-value: {:.4f}\n\n", diagnostics.jarque_bera.p_value);
+
+        if (diagnostics.adf.has_value()) {
+            fmt::print("Augmented Dickey-Fuller Test:\n");
+            fmt::print("  Statistic: {:.4f}\n", diagnostics.adf->statistic);
+            fmt::print("  P-value: {:.4f}\n", diagnostics.adf->p_value);
+            fmt::print("  Lags: {}\n", diagnostics.adf->lags);
+            fmt::print("  Critical values:\n");
+            fmt::print("    1%:  {:.4f}\n", diagnostics.adf->critical_value_1pct);
+            fmt::print("    5%:  {:.4f}\n", diagnostics.adf->critical_value_5pct);
+            fmt::print("    10%: {:.4f}\n\n", diagnostics.adf->critical_value_10pct);
+        }
+
+        if (!outputFile.empty()) {
+            nlohmann::json j;
+            j["ljung_box_residuals"]["statistic"] = diagnostics.ljung_box_residuals.statistic;
+            j["ljung_box_residuals"]["p_value"] = diagnostics.ljung_box_residuals.p_value;
+            j["ljung_box_residuals"]["dof"] = diagnostics.ljung_box_residuals.dof;
+            j["ljung_box_residuals"]["lags"] = diagnostics.ljung_box_residuals.lags;
+
+            j["ljung_box_squared"]["statistic"] = diagnostics.ljung_box_squared.statistic;
+            j["ljung_box_squared"]["p_value"] = diagnostics.ljung_box_squared.p_value;
+            j["ljung_box_squared"]["dof"] = diagnostics.ljung_box_squared.dof;
+            j["ljung_box_squared"]["lags"] = diagnostics.ljung_box_squared.lags;
+
+            j["jarque_bera"]["statistic"] = diagnostics.jarque_bera.statistic;
+            j["jarque_bera"]["p_value"] = diagnostics.jarque_bera.p_value;
+
+            if (diagnostics.adf.has_value()) {
+                j["adf"]["statistic"] = diagnostics.adf->statistic;
+                j["adf"]["p_value"] = diagnostics.adf->p_value;
+                j["adf"]["lags"] = diagnostics.adf->lags;
+                j["adf"]["critical_value_1pct"] = diagnostics.adf->critical_value_1pct;
+                j["adf"]["critical_value_5pct"] = diagnostics.adf->critical_value_5pct;
+                j["adf"]["critical_value_10pct"] = diagnostics.adf->critical_value_10pct;
+            }
+
+            std::ofstream file(outputFile);
+            if (file) {
+                file << j.dump(2);
+                fmt::print("Diagnostics saved to {}\n", outputFile);
+            } else {
+                fmt::print("Warning: Failed to save diagnostics to {}\n", outputFile);
+            }
+        }
+
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/handlers/FitHandler.cpp
+++ b/src/cli/handlers/FitHandler.cpp
@@ -1,0 +1,86 @@
+#include "ag/api/Engine.hpp"
+#include "ag/cli/CliUtils.hpp"
+#include "ag/io/Json.hpp"
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/report/FitSummary.hpp"
+
+#include <string>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+int handleFit(const std::string& dataFile, const std::string& arimaOrder,
+              const std::string& garchOrder, const std::string& outputFile, bool no_header,
+              bool use_student_t, double student_t_df) {
+    return executeWithErrorHandling([&]() {
+        fmt::print("Loading data from {}...\n", dataFile);
+        auto data = loadData(dataFile, !no_header);
+        fmt::print("Loaded {} observations\n", data.size());
+
+        int p = 0, d = 0, q = 0;
+        int P = 0, Q = 0;
+
+        if (!arimaOrder.empty()) {
+            auto arima_tuple = parseArimaOrder(arimaOrder);
+            p = std::get<0>(arima_tuple);
+            d = std::get<1>(arima_tuple);
+            q = std::get<2>(arima_tuple);
+        }
+        if (!garchOrder.empty()) {
+            auto garch_tuple = parseGarchOrder(garchOrder);
+            P = std::get<0>(garch_tuple);
+            Q = std::get<1>(garch_tuple);
+        }
+
+        if (arimaOrder.empty() && garchOrder.empty()) {
+            fmt::print("Error: Must specify at least --arima or --garch parameters\n");
+            return 1;
+        }
+
+        ag::models::ArimaGarchSpec spec(p, d, q, P, Q);
+
+        const std::string dist_str = use_student_t
+                                         ? fmt::format(" with Student-t(df={:.1f})", student_t_df)
+                                         : " with Gaussian innovations";
+        if (arimaOrder.empty()) {
+            fmt::print(
+                "Fitting GARCH({},{}) model (ARIMA component uses defaults: ARIMA(0,0,0)){}...\n",
+                P, Q, dist_str);
+        } else if (garchOrder.empty()) {
+            fmt::print("Fitting ARIMA({},{},{}) model (no GARCH component){}...\n", p, d, q,
+                       dist_str);
+        } else {
+            fmt::print("Fitting ARIMA({},{},{})-GARCH({},{}) model{}...\n", p, d, q, P, Q,
+                       dist_str);
+        }
+
+        ag::api::Engine engine;
+        auto fit_result = engine.fit(data, spec, true, use_student_t, student_t_df);
+        if (!fit_result) {
+            fmt::print("Error: {}\n", fit_result.error().message);
+            return 1;
+        }
+
+        fmt::print("✅ Model fitted successfully\n");
+        fmt::print("Converged: {}\n", fit_result.value().summary.converged);
+        fmt::print("Iterations: {}\n", fit_result.value().summary.iterations);
+        fmt::print("AIC: {:.4f}\n", fit_result.value().summary.aic);
+        fmt::print("BIC: {:.4f}\n", fit_result.value().summary.bic);
+
+        if (!outputFile.empty()) {
+            auto save_result = ag::io::JsonWriter::saveModel(outputFile, *fit_result.value().model);
+            if (save_result) {
+                fmt::print("Model saved to {}\n", outputFile);
+            } else {
+                fmt::print("Warning: Failed to save model to {}\n", outputFile);
+            }
+        }
+
+        fmt::print("\n{}\n", ag::report::generateTextReport(fit_result.value().summary));
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/handlers/ForecastHandler.cpp
+++ b/src/cli/handlers/ForecastHandler.cpp
@@ -1,0 +1,60 @@
+#include "ag/api/Engine.hpp"
+#include "ag/io/Json.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <string>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+int handleForecast(const std::string& modelFile, int horizon, const std::string& outputFile) {
+    return executeWithErrorHandling([&]() {
+        fmt::print("Loading model from {}...\n", modelFile);
+        auto model_result = ag::io::JsonReader::loadModel(modelFile);
+        if (!model_result) {
+            fmt::print("Error: Failed to load model from {}\n", modelFile);
+            return 1;
+        }
+
+        fmt::print("Generating {}-step ahead forecasts...\n", horizon);
+
+        ag::api::Engine engine;
+        auto forecast_result = engine.forecast(*model_result, horizon);
+        if (!forecast_result) {
+            fmt::print("Error: {}\n", forecast_result.error().message);
+            return 1;
+        }
+
+        fmt::print("✅ Forecasts generated\n\n");
+        fmt::print("Step  Mean Forecast  Std Dev\n");
+        fmt::print("----  -------------  -------\n");
+
+        for (int i = 0; i < horizon; ++i) {
+            fmt::print("{:4d}  {:13.6f}  {:7.6f}\n", i + 1,
+                       forecast_result.value().mean_forecasts[i],
+                       std::sqrt(forecast_result.value().variance_forecasts[i]));
+        }
+
+        if (!outputFile.empty()) {
+            std::ofstream file(outputFile);
+            if (!file) {
+                fmt::print("Warning: Failed to open output file {}\n", outputFile);
+                return 0;
+            }
+            file << "step,mean,variance,std_dev\n";
+            for (int i = 0; i < horizon; ++i) {
+                file << (i + 1) << "," << forecast_result.value().mean_forecasts[i] << ","
+                     << forecast_result.value().variance_forecasts[i] << ","
+                     << std::sqrt(forecast_result.value().variance_forecasts[i]) << "\n";
+            }
+            fmt::print("\nForecasts saved to {}\n", outputFile);
+        }
+
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/handlers/SelectHandler.cpp
+++ b/src/cli/handlers/SelectHandler.cpp
@@ -1,0 +1,98 @@
+#include "ag/api/Engine.hpp"
+#include "ag/cli/CliUtils.hpp"
+#include "ag/io/Json.hpp"
+#include "ag/report/FitSummary.hpp"
+#include "ag/selection/CandidateGrid.hpp"
+#include "ag/selection/ModelSelector.hpp"
+
+#include <algorithm>
+#include <string>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+int handleSelect(const std::string& dataFile, int maxP, int maxD, int maxQ, int maxGarchP,
+                 int maxGarchQ, const std::string& criterion, const std::string& outputFile,
+                 int topK, bool no_header) {
+    return executeWithErrorHandling([&]() {
+        fmt::print("Loading data from {}...\n", dataFile);
+        auto data = loadData(dataFile, !no_header);
+        fmt::print("Loaded {} observations\n", data.size());
+
+        ag::selection::CandidateGridConfig config(maxP, maxD, maxQ, maxGarchP, maxGarchQ);
+        ag::selection::CandidateGrid grid(config);
+        auto candidates = grid.generate();
+
+        fmt::print("Generated {} candidate models\n", candidates.size());
+        fmt::print("Performing model selection using {}...\n", criterion);
+
+        ag::selection::SelectionCriterion crit = ag::selection::SelectionCriterion::BIC;
+        if (criterion == "AIC") {
+            crit = ag::selection::SelectionCriterion::AIC;
+        } else if (criterion == "AICc") {
+            crit = ag::selection::SelectionCriterion::AICc;
+        } else if (criterion == "CV") {
+            crit = ag::selection::SelectionCriterion::CV;
+        }
+
+        ag::api::Engine engine;
+        const bool build_ranking = (topK > 0);
+        auto select_result = engine.auto_select(data, candidates, crit, build_ranking);
+        if (!select_result) {
+            fmt::print("Error: {}\n", select_result.error().message);
+            return 1;
+        }
+
+        auto& result = select_result.value();
+        const auto& spec = result.selected_spec;
+
+        fmt::print("✅ Model selection completed\n");
+        fmt::print("Best model: ARIMA({},{},{})-GARCH({},{})\n", spec.arimaSpec.p, spec.arimaSpec.d,
+                   spec.arimaSpec.q, spec.garchSpec.p, spec.garchSpec.q);
+        fmt::print("Candidates evaluated: {}\n", result.candidates_evaluated);
+        fmt::print("Candidates failed: {}\n", result.candidates_failed);
+        fmt::print("AIC: {:.4f}\n", result.summary.aic);
+        fmt::print("BIC: {:.4f}\n", result.summary.bic);
+
+        if (topK > 0 && !result.ranking.empty()) {
+            const int display_count = std::min(topK, static_cast<int>(result.ranking.size()));
+            fmt::print("\n=== Model Ranking (Top {}) ===\n", display_count);
+
+            const int rank_width = 6;
+            const int model_width = 20;
+            const int score_width = 12;
+            const int converged_width = 12;
+            const int total_width = rank_width + model_width + score_width + converged_width;
+
+            fmt::print("{:<6} {:<20} {:<12} {:<12}\n", "Rank", "Model", criterion, "Converged");
+            fmt::print("{:-<{}}\n", "", total_width);
+
+            int rank = 1;
+            for (int i = 0; i < display_count; ++i) {
+                const auto& entry = result.ranking[i];
+                const std::string model_str =
+                    fmt::format("ARIMA({},{},{})-GARCH({},{})", entry.p, entry.d, entry.q,
+                                entry.garch_p, entry.garch_q);
+                fmt::print("{:<6} {:<20} {:<12.4f} {:<12}\n", rank++, model_str, entry.score,
+                           entry.converged ? "Yes" : "No");
+            }
+            fmt::print("\n");
+        }
+
+        if (!outputFile.empty()) {
+            auto save_result = ag::io::JsonWriter::saveModel(outputFile, *result.model);
+            if (save_result) {
+                fmt::print("Model saved to {}\n", outputFile);
+            } else {
+                fmt::print("Warning: Failed to save model to {}\n", outputFile);
+            }
+        }
+
+        fmt::print("\n{}\n", ag::report::generateTextReport(result.summary));
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/handlers/SimulateFromModelHandler.cpp
+++ b/src/cli/handlers/SimulateFromModelHandler.cpp
@@ -1,0 +1,109 @@
+#include "ag/io/Json.hpp"
+#include "ag/models/composite/ArimaGarchModel.hpp"
+#include "ag/simulation/ArimaGarchSimulator.hpp"
+#include "ag/stats/Descriptive.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+int handleSimulateFromModel(const std::string& modelFile, int numPaths, int length,
+                            unsigned int seed, const std::string& outputFile, bool computeStats) {
+    return executeWithErrorHandling([&]() {
+        fmt::print("Loading model from {}...\n", modelFile);
+        auto model_result = ag::io::JsonReader::loadModel(modelFile);
+        if (!model_result) {
+            fmt::print("Error: Failed to load model from {}\n", modelFile);
+            return 1;
+        }
+
+        auto& model = *model_result;
+        const auto& spec = model.getSpec();
+        fmt::print("Model: ARIMA({},{},{})-GARCH({},{})\n", spec.arimaSpec.p, spec.arimaSpec.d,
+                   spec.arimaSpec.q, spec.garchSpec.p, spec.garchSpec.q);
+
+        ag::models::composite::ArimaGarchParameters params(spec);
+        params.arima_params = model.getArimaParams();
+        params.garch_params = model.getGarchParams();
+
+        fmt::print("Simulating {} paths of {} observations each (seed={})...\n", numPaths, length,
+                   seed);
+
+        ag::simulation::ArimaGarchSimulator simulator(spec, params);
+
+        std::vector<ag::simulation::SimulationResult> all_paths;
+        all_paths.reserve(numPaths);
+        for (int path = 0; path < numPaths; ++path) {
+            // Hash-based seeding avoids overflow and yields a good
+            // distribution while keeping each path reproducible from the
+            // base seed.
+            const unsigned int path_seed = seed ^ (std::hash<int>{}(path) + 0x9e3779b9);
+            all_paths.push_back(simulator.simulate(length, path_seed));
+        }
+
+        fmt::print("✅ Simulation completed\n");
+
+        if (!outputFile.empty()) {
+            std::ofstream file(outputFile);
+            if (!file) {
+                fmt::print("Error: Failed to open output file {}\n", outputFile);
+                return 1;
+            }
+            file << "path,observation,return,volatility\n";
+            for (int path = 0; path < numPaths; ++path) {
+                const auto& result = all_paths[path];
+                for (std::size_t i = 0; i < result.returns.size(); ++i) {
+                    file << (path + 1) << "," << (i + 1) << "," << result.returns[i] << ","
+                         << result.volatilities[i] << "\n";
+                }
+            }
+            fmt::print("Simulation results saved to {}\n", outputFile);
+        }
+
+        if (computeStats) {
+            fmt::print("\n=== Summary Statistics Across All Paths ===\n");
+
+            std::vector<double> all_returns;
+            all_returns.reserve(static_cast<std::size_t>(numPaths) * length);
+            for (const auto& result : all_paths) {
+                all_returns.insert(all_returns.end(), result.returns.begin(), result.returns.end());
+            }
+
+            const double mean_ret = ag::stats::mean(all_returns);
+            const double std_ret = std::sqrt(ag::stats::variance(all_returns));
+            const double min_ret = *std::min_element(all_returns.begin(), all_returns.end());
+            const double max_ret = *std::max_element(all_returns.begin(), all_returns.end());
+            const double skew_ret = ag::stats::skewness(all_returns);
+            const double kurt_ret = ag::stats::kurtosis(all_returns);
+
+            fmt::print("Returns (aggregated over {} paths):\n", numPaths);
+            fmt::print("  Mean:     {:.6f}\n", mean_ret);
+            fmt::print("  Std Dev:  {:.6f}\n", std_ret);
+            fmt::print("  Min:      {:.6f}\n", min_ret);
+            fmt::print("  Max:      {:.6f}\n", max_ret);
+            fmt::print("  Skewness: {:.6f}\n", skew_ret);
+            fmt::print("  Kurtosis: {:.6f}\n", kurt_ret);
+
+            fmt::print("\nFirst path statistics (for reproducibility check):\n");
+            const auto& first_path = all_paths[0];
+            fmt::print("  First 5 returns: ");
+            for (int i = 0; i < std::min(5, static_cast<int>(first_path.returns.size())); ++i) {
+                fmt::print("{:.6f} ", first_path.returns[i]);
+            }
+            fmt::print("\n");
+        }
+
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/handlers/SimulateHandler.cpp
+++ b/src/cli/handlers/SimulateHandler.cpp
@@ -1,0 +1,67 @@
+#include "ag/api/Engine.hpp"
+#include "ag/cli/CliUtils.hpp"
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/models/composite/ArimaGarchModel.hpp"
+
+#include <fstream>
+#include <string>
+
+#include "Handlers.hpp"
+#include <fmt/core.h>
+
+namespace ag::cli {
+
+int handleSimulate(const std::string& arimaOrder, const std::string& garchOrder, int length,
+                   unsigned int seed, const std::string& outputFile, bool use_student_t,
+                   double student_t_df) {
+    return executeWithErrorHandling([&]() {
+        auto [p, d, q] = parseArimaOrder(arimaOrder);
+        auto [P, Q] = parseGarchOrder(garchOrder);
+        ag::models::ArimaGarchSpec spec(p, d, q, P, Q);
+
+        ag::models::composite::ArimaGarchParameters params(spec);
+        params.arima_params.intercept = 0.0;
+        if (p > 0)
+            params.arima_params.ar_coef[0] = 0.5;
+        if (q > 0)
+            params.arima_params.ma_coef[0] = 0.3;
+        params.garch_params.omega = 0.01;
+        if (P > 0)
+            params.garch_params.alpha_coef[0] = 0.1;
+        if (Q > 0)
+            params.garch_params.beta_coef[0] = 0.85;
+
+        const std::string dist_str = use_student_t
+                                         ? fmt::format(" with Student-t(df={:.1f})", student_t_df)
+                                         : " with Gaussian innovations";
+        fmt::print("Simulating {} observations from ARIMA({},{},{})-GARCH({},{}) model{}...\n",
+                   length, p, d, q, P, Q, dist_str);
+
+        ag::api::Engine engine;
+        auto sim_result = engine.simulate(spec, params, length, seed, use_student_t, student_t_df);
+        if (!sim_result) {
+            fmt::print("Error: {}\n", sim_result.error().message);
+            return 1;
+        }
+
+        fmt::print("✅ Simulation completed\n");
+
+        if (!outputFile.empty()) {
+            std::ofstream file(outputFile);
+            if (!file) {
+                fmt::print("Warning: Failed to open output file {}\n", outputFile);
+                return 0;
+            }
+            file << "observation,return,volatility\n";
+            for (size_t i = 0; i < sim_result.value().returns.size(); ++i) {
+                file << (i + 1) << "," << sim_result.value().returns[i] << ","
+                     << sim_result.value().volatilities[i] << "\n";
+            }
+            fmt::print("Simulation saved to {}\n", outputFile);
+        }
+
+        return 0;
+    });
+}
+
+}  // namespace ag::cli

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2,557 +2,23 @@
  * @file cli/main.cpp
  * @brief Command-line interface for ARIMA-GARCH modeling.
  *
- * Provides subcommands for:
- * - fit: Fit ARIMA-GARCH model to data
- * - select: Automatic model selection
- * - forecast: Generate forecasts
- * - simulate: Simulate synthetic data
- * - diagnostics: Run diagnostic tests
+ * Argument parsing and subcommand dispatch. The actual command
+ * implementations live under src/cli/handlers/.
  */
 
 #include "ag/Version.hpp"
-#include "ag/api/Engine.hpp"
-#include "ag/cli/CliUtils.hpp"
-#include "ag/io/Json.hpp"
-#include "ag/models/ArimaGarchSpec.hpp"
-#include "ag/report/FitSummary.hpp"
-#include "ag/selection/CandidateGrid.hpp"
-#include "ag/simulation/ArimaGarchSimulator.hpp"
-#include "ag/stats/Descriptive.hpp"
 
-#include <algorithm>
-#include <fstream>
-#include <functional>
-#include <iostream>
-#include <sstream>
 #include <string>
-#include <vector>
 
+#include "Handlers.hpp"
 #include <CLI/CLI.hpp>
-#include <fmt/core.h>
-#include <nlohmann/json.hpp>
-
-using ag::api::Engine;
-using ag::models::ArimaGarchSpec;
-
-// Error handling wrapper for CLI handlers
-template <typename Func>
-int executeWithErrorHandling(Func&& func) {
-    try {
-        return func();
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
-
-// Fit subcommand handler
-int handleFit(const std::string& dataFile, const std::string& arimaOrder,
-              const std::string& garchOrder, const std::string& outputFile, bool no_header,
-              bool use_student_t, double student_t_df) {
-    return executeWithErrorHandling([&]() {
-        fmt::print("Loading data from {}...\n", dataFile);
-        auto data = ag::cli::loadData(dataFile, !no_header);
-        fmt::print("Loaded {} observations\n", data.size());
-
-        // Parse model specification with support for ARIMA-only models
-        int p = 0, d = 0, q = 0;
-        int P = 0, Q = 0;  // Default to no GARCH
-
-        // Parse ARIMA order if provided, otherwise default to ARIMA(0,0,0)
-        if (!arimaOrder.empty()) {
-            auto arima_tuple = ag::cli::parseArimaOrder(arimaOrder);
-            p = std::get<0>(arima_tuple);
-            d = std::get<1>(arima_tuple);
-            q = std::get<2>(arima_tuple);
-        }
-
-        // Parse GARCH order if provided, otherwise no GARCH
-        if (!garchOrder.empty()) {
-            auto garch_tuple = ag::cli::parseGarchOrder(garchOrder);
-            P = std::get<0>(garch_tuple);
-            Q = std::get<1>(garch_tuple);
-        }
-
-        // Ensure at least one component is specified
-        if (arimaOrder.empty() && garchOrder.empty()) {
-            fmt::print("Error: Must specify at least --arima or --garch parameters\n");
-            return 1;
-        }
-
-        ArimaGarchSpec spec(p, d, q, P, Q);
-
-        // Print appropriate model description
-        std::string dist_str = use_student_t
-                                   ? fmt::format(" with Student-t(df={:.1f})", student_t_df)
-                                   : " with Gaussian innovations";
-        if (arimaOrder.empty()) {
-            fmt::print(
-                "Fitting GARCH({},{}) model (ARIMA component uses defaults: ARIMA(0,0,0)){}...\n",
-                P, Q, dist_str);
-        } else if (garchOrder.empty()) {
-            fmt::print("Fitting ARIMA({},{},{}) model (no GARCH component){}...\n", p, d, q,
-                       dist_str);
-        } else {
-            fmt::print("Fitting ARIMA({},{},{})-GARCH({},{}) model{}...\n", p, d, q, P, Q,
-                       dist_str);
-        }
-
-        Engine engine;
-        auto fit_result = engine.fit(data, spec, true, use_student_t, student_t_df);
-
-        if (!fit_result) {
-            fmt::print("Error: {}\n", fit_result.error().message);
-            return 1;
-        }
-
-        fmt::print("✅ Model fitted successfully\n");
-        fmt::print("Converged: {}\n", fit_result.value().summary.converged);
-        fmt::print("Iterations: {}\n", fit_result.value().summary.iterations);
-        fmt::print("AIC: {:.4f}\n", fit_result.value().summary.aic);
-        fmt::print("BIC: {:.4f}\n", fit_result.value().summary.bic);
-
-        // Save model to file
-        if (!outputFile.empty()) {
-            auto save_result = ag::io::JsonWriter::saveModel(outputFile, *fit_result.value().model);
-            if (save_result) {
-                fmt::print("Model saved to {}\n", outputFile);
-            } else {
-                fmt::print("Warning: Failed to save model to {}\n", outputFile);
-            }
-        }
-
-        // Print fit summary report
-        fmt::print("\n{}\n", ag::report::generateTextReport(fit_result.value().summary));
-
-        return 0;
-    });
-}
-
-// Select subcommand handler
-int handleSelect(const std::string& dataFile, int maxP, int maxD, int maxQ, int maxGarchP,
-                 int maxGarchQ, const std::string& criterion, const std::string& outputFile,
-                 int topK, bool no_header) {
-    try {
-        fmt::print("Loading data from {}...\n", dataFile);
-        auto data = ag::cli::loadData(dataFile, !no_header);
-        fmt::print("Loaded {} observations\n", data.size());
-
-        // Generate candidate grid
-        ag::selection::CandidateGridConfig config(maxP, maxD, maxQ, maxGarchP, maxGarchQ);
-        ag::selection::CandidateGrid grid(config);
-        auto candidates = grid.generate();
-
-        fmt::print("Generated {} candidate models\n", candidates.size());
-        fmt::print("Performing model selection using {}...\n", criterion);
-
-        // Parse selection criterion
-        ag::selection::SelectionCriterion crit = ag::selection::SelectionCriterion::BIC;
-        if (criterion == "AIC") {
-            crit = ag::selection::SelectionCriterion::AIC;
-        } else if (criterion == "AICc") {
-            crit = ag::selection::SelectionCriterion::AICc;
-        } else if (criterion == "CV") {
-            crit = ag::selection::SelectionCriterion::CV;
-        }
-
-        Engine engine;
-        bool build_ranking = (topK > 0);
-        auto select_result = engine.auto_select(data, candidates, crit, build_ranking);
-
-        if (!select_result) {
-            fmt::print("Error: {}\n", select_result.error().message);
-            return 1;
-        }
-
-        auto& result = select_result.value();
-        auto& spec = result.selected_spec;
-
-        fmt::print("✅ Model selection completed\n");
-        fmt::print("Best model: ARIMA({},{},{})-GARCH({},{})\n", spec.arimaSpec.p, spec.arimaSpec.d,
-                   spec.arimaSpec.q, spec.garchSpec.p, spec.garchSpec.q);
-        fmt::print("Candidates evaluated: {}\n", result.candidates_evaluated);
-        fmt::print("Candidates failed: {}\n", result.candidates_failed);
-        fmt::print("AIC: {:.4f}\n", result.summary.aic);
-        fmt::print("BIC: {:.4f}\n", result.summary.bic);
-
-        // Print ranking table if requested
-        if (topK > 0 && !result.ranking.empty()) {
-            fmt::print("\n=== Model Ranking (Top {}) ===\n",
-                       std::min(topK, static_cast<int>(result.ranking.size())));
-
-            // Calculate dynamic table width based on column widths
-            const int rank_width = 6;
-            const int model_width = 20;
-            const int score_width = 12;
-            const int converged_width = 12;
-            const int total_width = rank_width + model_width + score_width + converged_width;
-
-            fmt::print("{:<6} {:<20} {:<12} {:<12}\n", "Rank", "Model", criterion, "Converged");
-            fmt::print("{:-<{}}\n", "", total_width);
-
-            int rank = 1;
-            int display_count = std::min(topK, static_cast<int>(result.ranking.size()));
-            for (int i = 0; i < display_count; ++i) {
-                const auto& entry = result.ranking[i];
-                std::string model_str = fmt::format("ARIMA({},{},{})-GARCH({},{})", entry.p,
-                                                    entry.d, entry.q, entry.garch_p, entry.garch_q);
-                fmt::print("{:<6} {:<20} {:<12.4f} {:<12}\n", rank++, model_str, entry.score,
-                           entry.converged ? "Yes" : "No");
-            }
-            fmt::print("\n");
-        }
-
-        // Save model to file
-        if (!outputFile.empty()) {
-            auto save_result = ag::io::JsonWriter::saveModel(outputFile, *result.model);
-            if (save_result) {
-                fmt::print("Model saved to {}\n", outputFile);
-            } else {
-                fmt::print("Warning: Failed to save model to {}\n", outputFile);
-            }
-        }
-
-        // Print fit summary
-        fmt::print("\n{}\n", ag::report::generateTextReport(result.summary));
-
-        return 0;
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
-
-// Forecast subcommand handler
-int handleForecast(const std::string& modelFile, int horizon, const std::string& outputFile) {
-    try {
-        fmt::print("Loading model from {}...\n", modelFile);
-        auto model_result = ag::io::JsonReader::loadModel(modelFile);
-        if (!model_result) {
-            fmt::print("Error: Failed to load model from {}\n", modelFile);
-            return 1;
-        }
-
-        fmt::print("Generating {}-step ahead forecasts...\n", horizon);
-
-        Engine engine;
-        auto forecast_result = engine.forecast(*model_result, horizon);
-
-        if (!forecast_result) {
-            fmt::print("Error: {}\n", forecast_result.error().message);
-            return 1;
-        }
-
-        fmt::print("✅ Forecasts generated\n\n");
-        fmt::print("Step  Mean Forecast  Std Dev\n");
-        fmt::print("----  -------------  -------\n");
-
-        for (int i = 0; i < horizon; ++i) {
-            fmt::print("{:4d}  {:13.6f}  {:7.6f}\n", i + 1,
-                       forecast_result.value().mean_forecasts[i],
-                       std::sqrt(forecast_result.value().variance_forecasts[i]));
-        }
-
-        // Save forecasts to file
-        if (!outputFile.empty()) {
-            std::ofstream file(outputFile);
-            if (!file) {
-                fmt::print("Warning: Failed to open output file {}\n", outputFile);
-                return 0;
-            }
-            file << "step,mean,variance,std_dev\n";
-            for (int i = 0; i < horizon; ++i) {
-                file << (i + 1) << "," << forecast_result.value().mean_forecasts[i] << ","
-                     << forecast_result.value().variance_forecasts[i] << ","
-                     << std::sqrt(forecast_result.value().variance_forecasts[i]) << "\n";
-            }
-            fmt::print("\nForecasts saved to {}\n", outputFile);
-        }
-
-        return 0;
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
-
-// Simulate subcommand handler
-int handleSimulate(const std::string& arimaOrder, const std::string& garchOrder, int length,
-                   unsigned int seed, const std::string& outputFile, bool use_student_t,
-                   double student_t_df) {
-    try {
-        // Parse model specification
-        auto [p, d, q] = ag::cli::parseArimaOrder(arimaOrder);
-        auto [P, Q] = ag::cli::parseGarchOrder(garchOrder);
-        ArimaGarchSpec spec(p, d, q, P, Q);
-
-        // Use default parameters for simulation
-        ag::models::composite::ArimaGarchParameters params(spec);
-        params.arima_params.intercept = 0.0;
-        if (p > 0)
-            params.arima_params.ar_coef[0] = 0.5;
-        if (q > 0)
-            params.arima_params.ma_coef[0] = 0.3;
-        params.garch_params.omega = 0.01;
-        if (P > 0)
-            params.garch_params.alpha_coef[0] = 0.1;
-        if (Q > 0)
-            params.garch_params.beta_coef[0] = 0.85;
-
-        std::string dist_str = use_student_t
-                                   ? fmt::format(" with Student-t(df={:.1f})", student_t_df)
-                                   : " with Gaussian innovations";
-        fmt::print("Simulating {} observations from ARIMA({},{},{})-GARCH({},{}) model{}...\n",
-                   length, p, d, q, P, Q, dist_str);
-
-        Engine engine;
-        auto sim_result = engine.simulate(spec, params, length, seed, use_student_t, student_t_df);
-
-        if (!sim_result) {
-            fmt::print("Error: {}\n", sim_result.error().message);
-            return 1;
-        }
-
-        fmt::print("✅ Simulation completed\n");
-
-        // Save simulation to file
-        if (!outputFile.empty()) {
-            std::ofstream file(outputFile);
-            if (!file) {
-                fmt::print("Warning: Failed to open output file {}\n", outputFile);
-                return 0;
-            }
-            file << "observation,return,volatility\n";
-            for (size_t i = 0; i < sim_result.value().returns.size(); ++i) {
-                file << (i + 1) << "," << sim_result.value().returns[i] << ","
-                     << sim_result.value().volatilities[i] << "\n";
-            }
-            fmt::print("Simulation saved to {}\n", outputFile);
-        }
-
-        return 0;
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
-
-// Simulate from saved model subcommand handler
-int handleSimulateFromModel(const std::string& modelFile, int numPaths, int length,
-                            unsigned int seed, const std::string& outputFile, bool computeStats) {
-    try {
-        fmt::print("Loading model from {}...\n", modelFile);
-        auto model_result = ag::io::JsonReader::loadModel(modelFile);
-        if (!model_result) {
-            fmt::print("Error: Failed to load model from {}\n", modelFile);
-            return 1;
-        }
-
-        auto& model = *model_result;
-        const auto& spec = model.getSpec();
-
-        fmt::print("Model: ARIMA({},{},{})-GARCH({},{})\n", spec.arimaSpec.p, spec.arimaSpec.d,
-                   spec.arimaSpec.q, spec.garchSpec.p, spec.garchSpec.q);
-
-        // Get parameters from the loaded model
-        ag::models::composite::ArimaGarchParameters params(spec);
-        params.arima_params = model.getArimaParams();
-        params.garch_params = model.getGarchParams();
-
-        fmt::print("Simulating {} paths of {} observations each (seed={})...\n", numPaths, length,
-                   seed);
-
-        // Create simulator with loaded parameters
-        ag::simulation::ArimaGarchSimulator simulator(spec, params);
-
-        // Generate all paths
-        std::vector<ag::simulation::SimulationResult> all_paths;
-        all_paths.reserve(numPaths);
-
-        for (int path = 0; path < numPaths; ++path) {
-            // Use hash-based seeding to avoid overflow and ensure good distribution
-            // Each path gets a unique but reproducible seed based on the base seed
-            unsigned int path_seed = seed ^ (std::hash<int>{}(path) + 0x9e3779b9);
-            auto result = simulator.simulate(length, path_seed);
-            all_paths.push_back(std::move(result));
-        }
-
-        fmt::print("✅ Simulation completed\n");
-
-        // Save results to CSV
-        if (!outputFile.empty()) {
-            std::ofstream file(outputFile);
-            if (!file) {
-                fmt::print("Error: Failed to open output file {}\n", outputFile);
-                return 1;
-            }
-
-            // Write header
-            file << "path,observation,return,volatility\n";
-
-            // Write all paths
-            for (int path = 0; path < numPaths; ++path) {
-                const auto& result = all_paths[path];
-                for (size_t i = 0; i < result.returns.size(); ++i) {
-                    file << (path + 1) << "," << (i + 1) << "," << result.returns[i] << ","
-                         << result.volatilities[i] << "\n";
-                }
-            }
-
-            fmt::print("Simulation results saved to {}\n", outputFile);
-        }
-
-        // Compute and display summary statistics if requested
-        if (computeStats) {
-            fmt::print("\n=== Summary Statistics Across All Paths ===\n");
-
-            // Aggregate all returns
-            std::vector<double> all_returns;
-            all_returns.reserve(numPaths * length);
-            for (const auto& result : all_paths) {
-                all_returns.insert(all_returns.end(), result.returns.begin(), result.returns.end());
-            }
-
-            double mean_ret = ag::stats::mean(all_returns);
-            double std_ret = std::sqrt(ag::stats::variance(all_returns));
-            double min_ret = *std::min_element(all_returns.begin(), all_returns.end());
-            double max_ret = *std::max_element(all_returns.begin(), all_returns.end());
-            double skew_ret = ag::stats::skewness(all_returns);
-            double kurt_ret = ag::stats::kurtosis(all_returns);
-
-            fmt::print("Returns (aggregated over {} paths):\n", numPaths);
-            fmt::print("  Mean:     {:.6f}\n", mean_ret);
-            fmt::print("  Std Dev:  {:.6f}\n", std_ret);
-            fmt::print("  Min:      {:.6f}\n", min_ret);
-            fmt::print("  Max:      {:.6f}\n", max_ret);
-            fmt::print("  Skewness: {:.6f}\n", skew_ret);
-            fmt::print("  Kurtosis: {:.6f}\n", kurt_ret);
-
-            // First path statistics
-            fmt::print("\nFirst path statistics (for reproducibility check):\n");
-            const auto& first_path = all_paths[0];
-            fmt::print("  First 5 returns: ");
-            for (int i = 0; i < std::min(5, static_cast<int>(first_path.returns.size())); ++i) {
-                fmt::print("{:.6f} ", first_path.returns[i]);
-            }
-            fmt::print("\n");
-        }
-
-        return 0;
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
-
-// Diagnostics subcommand handler
-int handleDiagnostics(const std::string& modelFile, const std::string& dataFile,
-                      const std::string& outputFile, bool no_header) {
-    try {
-        fmt::print("Loading model from {}...\n", modelFile);
-        auto model_result = ag::io::JsonReader::loadModel(modelFile);
-        if (!model_result) {
-            fmt::print("Error: Failed to load model from {}\n", modelFile);
-            return 1;
-        }
-
-        fmt::print("Loading data from {}...\n", dataFile);
-        auto data = ag::cli::loadData(dataFile, !no_header);
-        fmt::print("Loaded {} observations\n", data.size());
-
-        // Run diagnostics
-        fmt::print("Running diagnostic tests...\n");
-
-        auto& model = *model_result;
-        std::size_t ljung_box_lags = std::min(static_cast<std::size_t>(10), data.size() / 5);
-
-        // Reconstruct parameters from the model
-        ag::models::composite::ArimaGarchParameters params(model.getSpec());
-        params.arima_params = model.getArimaParams();
-        params.garch_params = model.getGarchParams();
-
-        auto diagnostics = ag::diagnostics::computeDiagnostics(model.getSpec(), params, data,
-                                                               ljung_box_lags, true);
-
-        fmt::print("✅ Diagnostics completed\n\n");
-
-        // Print diagnostics report
-        fmt::print("=== Diagnostic Tests ===\n\n");
-
-        fmt::print("Ljung-Box Test (raw residuals):\n");
-        fmt::print("  Statistic: {:.4f}\n", diagnostics.ljung_box_residuals.statistic);
-        fmt::print("  P-value: {:.4f}\n", diagnostics.ljung_box_residuals.p_value);
-        fmt::print("  DOF: {}\n", diagnostics.ljung_box_residuals.dof);
-        fmt::print("  Lags: {}\n\n", diagnostics.ljung_box_residuals.lags);
-
-        fmt::print("Ljung-Box Test (squared residuals):\n");
-        fmt::print("  Statistic: {:.4f}\n", diagnostics.ljung_box_squared.statistic);
-        fmt::print("  P-value: {:.4f}\n", diagnostics.ljung_box_squared.p_value);
-        fmt::print("  DOF: {}\n", diagnostics.ljung_box_squared.dof);
-        fmt::print("  Lags: {}\n\n", diagnostics.ljung_box_squared.lags);
-
-        fmt::print("Jarque-Bera Test:\n");
-        fmt::print("  Statistic: {:.4f}\n", diagnostics.jarque_bera.statistic);
-        fmt::print("  P-value: {:.4f}\n\n", diagnostics.jarque_bera.p_value);
-
-        if (diagnostics.adf.has_value()) {
-            fmt::print("Augmented Dickey-Fuller Test:\n");
-            fmt::print("  Statistic: {:.4f}\n", diagnostics.adf->statistic);
-            fmt::print("  P-value: {:.4f}\n", diagnostics.adf->p_value);
-            fmt::print("  Lags: {}\n", diagnostics.adf->lags);
-            fmt::print("  Critical values:\n");
-            fmt::print("    1%:  {:.4f}\n", diagnostics.adf->critical_value_1pct);
-            fmt::print("    5%:  {:.4f}\n", diagnostics.adf->critical_value_5pct);
-            fmt::print("    10%: {:.4f}\n\n", diagnostics.adf->critical_value_10pct);
-        }
-
-        // Save diagnostics to JSON file if requested
-        if (!outputFile.empty()) {
-            nlohmann::json j;
-            j["ljung_box_residuals"]["statistic"] = diagnostics.ljung_box_residuals.statistic;
-            j["ljung_box_residuals"]["p_value"] = diagnostics.ljung_box_residuals.p_value;
-            j["ljung_box_residuals"]["dof"] = diagnostics.ljung_box_residuals.dof;
-            j["ljung_box_residuals"]["lags"] = diagnostics.ljung_box_residuals.lags;
-
-            j["ljung_box_squared"]["statistic"] = diagnostics.ljung_box_squared.statistic;
-            j["ljung_box_squared"]["p_value"] = diagnostics.ljung_box_squared.p_value;
-            j["ljung_box_squared"]["dof"] = diagnostics.ljung_box_squared.dof;
-            j["ljung_box_squared"]["lags"] = diagnostics.ljung_box_squared.lags;
-
-            j["jarque_bera"]["statistic"] = diagnostics.jarque_bera.statistic;
-            j["jarque_bera"]["p_value"] = diagnostics.jarque_bera.p_value;
-
-            if (diagnostics.adf.has_value()) {
-                j["adf"]["statistic"] = diagnostics.adf->statistic;
-                j["adf"]["p_value"] = diagnostics.adf->p_value;
-                j["adf"]["lags"] = diagnostics.adf->lags;
-                j["adf"]["critical_value_1pct"] = diagnostics.adf->critical_value_1pct;
-                j["adf"]["critical_value_5pct"] = diagnostics.adf->critical_value_5pct;
-                j["adf"]["critical_value_10pct"] = diagnostics.adf->critical_value_10pct;
-            }
-
-            std::ofstream file(outputFile);
-            if (file) {
-                file << j.dump(2);
-                fmt::print("Diagnostics saved to {}\n", outputFile);
-            } else {
-                fmt::print("Warning: Failed to save diagnostics to {}\n", outputFile);
-            }
-        }
-
-        return 0;
-    } catch (const std::exception& e) {
-        fmt::print("Error: {}\n", e.what());
-        return 1;
-    }
-}
 
 int main(int argc, char* argv[]) {
     CLI::App app{"ARIMA-GARCH Time Series Modeling CLI", "ag"};
-    app.require_subcommand(0, 1);  // Allow 0 or 1 subcommand (0 for --help)
+    app.require_subcommand(0, 1);
     app.set_version_flag("--version,-v", ag::kVersion);
 
-    // Fit subcommand
+    // ----- fit -----
     auto* fit = app.add_subcommand("fit", "Fit ARIMA-GARCH model to time series data");
     std::string fit_data_file;
     std::string fit_arima_order;
@@ -572,16 +38,14 @@ int main(int argc, char* argv[]) {
     fit->add_option("--t-dist", fit_student_t_df,
                     "Use Student-t distribution with specified degrees of freedom (default: 2.0)")
         ->check(CLI::PositiveNumber);
-
     fit->callback([&]() {
-        // Check if Student-t flag was provided and set proper values
-        bool use_student_t = fit->count("--t-dist") > 0;
-        double df = use_student_t ? fit_student_t_df : 2.0;
-        return handleFit(fit_data_file, fit_arima_order, fit_garch_order, fit_output_file,
-                         fit_no_header, use_student_t, df);
+        const bool use_student_t = fit->count("--t-dist") > 0;
+        const double df = use_student_t ? fit_student_t_df : 2.0;
+        return ag::cli::handleFit(fit_data_file, fit_arima_order, fit_garch_order, fit_output_file,
+                                  fit_no_header, use_student_t, df);
     });
 
-    // Select subcommand
+    // ----- select -----
     auto* select = app.add_subcommand("select", "Automatic model selection from candidate grid");
     std::string select_data_file;
     int select_max_p = 2;
@@ -610,14 +74,13 @@ int main(int argc, char* argv[]) {
                        "Display top K models in ranking table (default: 0, disabled)");
     select->add_flag("--no-header", select_no_header,
                      "CSV file has no header row (default: expect header)");
-
     select->callback([&]() {
-        return handleSelect(select_data_file, select_max_p, select_max_d, select_max_q,
-                            select_max_garch_p, select_max_garch_q, select_criterion,
-                            select_output_file, select_top_k, select_no_header);
+        return ag::cli::handleSelect(select_data_file, select_max_p, select_max_d, select_max_q,
+                                     select_max_garch_p, select_max_garch_q, select_criterion,
+                                     select_output_file, select_top_k, select_no_header);
     });
 
-    // Forecast subcommand
+    // ----- forecast -----
     auto* forecast = app.add_subcommand("forecast", "Generate forecasts from fitted model");
     std::string forecast_model_file;
     int forecast_horizon = 10;
@@ -629,12 +92,11 @@ int main(int argc, char* argv[]) {
                          "Forecast horizon (number of steps ahead, default: 10)");
     forecast->add_option("-o,--output,--out", forecast_output_file,
                          "Output forecast file (CSV format)");
-
     forecast->callback([&]() {
-        return handleForecast(forecast_model_file, forecast_horizon, forecast_output_file);
+        return ag::cli::handleForecast(forecast_model_file, forecast_horizon, forecast_output_file);
     });
 
-    // Simulate subcommand
+    // ----- sim (synthetic from spec) -----
     auto* simulate = app.add_subcommand("sim", "Simulate synthetic time series data");
     std::string sim_arima_order;
     std::string sim_garch_order;
@@ -656,16 +118,14 @@ int main(int argc, char* argv[]) {
         ->add_option("--t-dist", sim_student_t_df,
                      "Use Student-t distribution with specified degrees of freedom (default: 2.0)")
         ->check(CLI::PositiveNumber);
-
     simulate->callback([&]() {
-        // Check if Student-t flag was provided and set proper values
-        bool use_student_t = simulate->count("--t-dist") > 0;
-        double df = use_student_t ? sim_student_t_df : 2.0;
-        return handleSimulate(sim_arima_order, sim_garch_order, sim_length, sim_seed,
-                              sim_output_file, use_student_t, df);
+        const bool use_student_t = simulate->count("--t-dist") > 0;
+        const double df = use_student_t ? sim_student_t_df : 2.0;
+        return ag::cli::handleSimulate(sim_arima_order, sim_garch_order, sim_length, sim_seed,
+                                       sim_output_file, use_student_t, df);
     });
 
-    // Simulate from saved model subcommand
+    // ----- simulate (multi-path from saved model) -----
     auto* simulate_model =
         app.add_subcommand("simulate", "Simulate multiple paths from a saved model");
     std::string simmodel_model_file;
@@ -688,13 +148,13 @@ int main(int argc, char* argv[]) {
         ->required();
     simulate_model->add_flag("--stats", simmodel_compute_stats,
                              "Compute and display summary statistics");
-
     simulate_model->callback([&]() {
-        return handleSimulateFromModel(simmodel_model_file, simmodel_num_paths, simmodel_length,
-                                       simmodel_seed, simmodel_output_file, simmodel_compute_stats);
+        return ag::cli::handleSimulateFromModel(simmodel_model_file, simmodel_num_paths,
+                                                simmodel_length, simmodel_seed,
+                                                simmodel_output_file, simmodel_compute_stats);
     });
 
-    // Diagnostics subcommand
+    // ----- diagnostics -----
     auto* diagnostics = app.add_subcommand("diagnostics", "Run diagnostic tests on fitted model");
     std::string diag_model_file;
     std::string diag_data_file;
@@ -711,13 +171,11 @@ int main(int argc, char* argv[]) {
                             "Output diagnostics file (JSON format)");
     diagnostics->add_flag("--no-header", diag_no_header,
                           "CSV file has no header row (default: expect header)");
-
     diagnostics->callback([&]() {
-        return handleDiagnostics(diag_model_file, diag_data_file, diag_output_file, diag_no_header);
+        return ag::cli::handleDiagnostics(diag_model_file, diag_data_file, diag_output_file,
+                                          diag_no_header);
     });
 
-    // Parse command line
     CLI11_PARSE(app, argc, argv);
-
     return 0;
 }

--- a/src/estimation/FitDriver.cpp
+++ b/src/estimation/FitDriver.cpp
@@ -1,0 +1,108 @@
+#include "ag/estimation/FitDriver.hpp"
+
+#include "ag/estimation/Likelihood.hpp"
+#include "ag/estimation/ParameterInitialization.hpp"
+#include "ag/estimation/ParameterVector.hpp"
+
+#include <stdexcept>
+
+namespace ag::estimation {
+
+std::optional<FitOutcome> runFit(const double* data, std::size_t n,
+                                 const ag::models::ArimaGarchSpec& spec,
+                                 const FitOptions& options) {
+    if (data == nullptr || n == 0) {
+        return std::nullopt;
+    }
+
+    // Initialize parameters from data. If this throws we report failure
+    // by returning nullopt -- the caller can't recover without more data.
+    ag::models::arima::ArimaParameters arima_init(spec.arimaSpec.p, spec.arimaSpec.q);
+    ag::models::garch::GarchParameters garch_init(spec.garchSpec.p, spec.garchSpec.q);
+    try {
+        auto initialized = initializeArimaGarchParameters(data, n, spec);
+        arima_init = std::move(initialized.first);
+        garch_init = std::move(initialized.second);
+    } catch (...) {
+        return std::nullopt;
+    }
+
+    const InnovationDistribution dist = options.innovation.type;
+    const double df = options.innovation.df;
+    ArimaGarchLikelihood likelihood(spec, dist);
+
+    std::vector<double> initial_params = param_vector::pack(spec, arima_init, garch_init);
+    if (initial_params.empty()) {
+        // Degenerate spec with no free parameters. Nothing to optimize.
+        FitOutcome outcome(spec);
+        outcome.parameters.arima_params = arima_init;
+        outcome.parameters.garch_params = garch_init;
+        try {
+            outcome.neg_log_likelihood =
+                likelihood.computeNegativeLogLikelihood(data, n, arima_init, garch_init, df);
+        } catch (...) {
+            return std::nullopt;
+        }
+        outcome.converged = true;
+        outcome.iterations = 0;
+        outcome.message = "No free parameters; returning initial values";
+        return outcome;
+    }
+
+    // Single canonical objective. Returns CONSTRAINT_PENALTY for
+    // infeasible parameter vectors and for exceptions raised by the
+    // likelihood (e.g. non-positive variance at a degenerate point).
+    auto objective = [&](const std::vector<double>& params) -> double {
+        ag::models::arima::ArimaParameters arima_p(spec.arimaSpec.p, spec.arimaSpec.q);
+        ag::models::garch::GarchParameters garch_p(spec.garchSpec.p, spec.garchSpec.q);
+        try {
+            param_vector::unpack(params, spec, arima_p, garch_p);
+        } catch (...) {
+            return CONSTRAINT_PENALTY;
+        }
+
+        if (!spec.garchSpec.isNull()) {
+            if (!garch_p.isPositive() || !garch_p.isStationary()) {
+                return CONSTRAINT_PENALTY;
+            }
+        }
+
+        try {
+            return likelihood.computeNegativeLogLikelihood(data, n, arima_p, garch_p, df);
+        } catch (...) {
+            return CONSTRAINT_PENALTY;
+        }
+    };
+
+    const OptimizerConfig& cfg = options.optimizer;
+    NelderMeadOptimizer optimizer(cfg.ftol, cfg.xtol, cfg.max_iterations);
+
+    OptimizationResultWithRestarts result;
+    try {
+        result = optimizeWithRestarts(optimizer, objective, initial_params, cfg.restarts,
+                                      cfg.perturbation_scale, cfg.seed);
+    } catch (...) {
+        return std::nullopt;
+    }
+
+    FitOutcome outcome(spec);
+    try {
+        param_vector::unpack(result.parameters, spec, outcome.parameters.arima_params,
+                             outcome.parameters.garch_params);
+    } catch (...) {
+        return std::nullopt;
+    }
+
+    // The unpacker leaves arima params at their constructed defaults when
+    // the spec is zero-order; carry over the initialized intercept (zero)
+    // and any state we'd expect for the report. For non-zero specs the
+    // unpacker has already filled them.
+    outcome.neg_log_likelihood = result.objective_value;
+    outcome.converged = result.converged;
+    outcome.iterations = result.iterations;
+    outcome.message = result.message;
+
+    return outcome;
+}
+
+}  // namespace ag::estimation

--- a/src/estimation/FitDriver.cpp
+++ b/src/estimation/FitDriver.cpp
@@ -15,16 +15,25 @@ std::optional<FitOutcome> runFit(const double* data, std::size_t n,
         return std::nullopt;
     }
 
-    // Initialize parameters from data. If this throws we report failure
-    // by returning nullopt -- the caller can't recover without more data.
+    // Initialize parameters from data. If this throws we return a non-
+    // converged outcome with the error message so the caller has actionable
+    // diagnostics (e.g. "Insufficient data after differencing").
     ag::models::arima::ArimaParameters arima_init(spec.arimaSpec.p, spec.arimaSpec.q);
     ag::models::garch::GarchParameters garch_init(spec.garchSpec.p, spec.garchSpec.q);
     try {
         auto initialized = initializeArimaGarchParameters(data, n, spec);
         arima_init = std::move(initialized.first);
         garch_init = std::move(initialized.second);
+    } catch (const std::exception& e) {
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = std::string("Parameter initialization failed: ") + e.what();
+        return failure;
     } catch (...) {
-        return std::nullopt;
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = "Parameter initialization failed: unknown error";
+        return failure;
     }
 
     const InnovationDistribution dist = options.innovation.type;
@@ -40,8 +49,14 @@ std::optional<FitOutcome> runFit(const double* data, std::size_t n,
         try {
             outcome.neg_log_likelihood =
                 likelihood.computeNegativeLogLikelihood(data, n, arima_init, garch_init, df);
+        } catch (const std::exception& e) {
+            outcome.converged = false;
+            outcome.message = std::string("Likelihood evaluation failed: ") + e.what();
+            return outcome;
         } catch (...) {
-            return std::nullopt;
+            outcome.converged = false;
+            outcome.message = "Likelihood evaluation failed: unknown error";
+            return outcome;
         }
         outcome.converged = true;
         outcome.iterations = 0;
@@ -81,16 +96,32 @@ std::optional<FitOutcome> runFit(const double* data, std::size_t n,
     try {
         result = optimizeWithRestarts(optimizer, objective, initial_params, cfg.restarts,
                                       cfg.perturbation_scale, cfg.seed);
+    } catch (const std::exception& e) {
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = std::string("Optimizer failed: ") + e.what();
+        return failure;
     } catch (...) {
-        return std::nullopt;
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = "Optimizer failed: unknown error";
+        return failure;
     }
 
     FitOutcome outcome(spec);
     try {
         param_vector::unpack(result.parameters, spec, outcome.parameters.arima_params,
                              outcome.parameters.garch_params);
+    } catch (const std::exception& e) {
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = std::string("Parameter unpack failed: ") + e.what();
+        return failure;
     } catch (...) {
-        return std::nullopt;
+        FitOutcome failure(spec);
+        failure.converged = false;
+        failure.message = "Parameter unpack failed: unknown error";
+        return failure;
     }
 
     // The unpacker leaves arima params at their constructed defaults when

--- a/src/estimation/Likelihood.cpp
+++ b/src/estimation/Likelihood.cpp
@@ -55,49 +55,28 @@ double ArimaGarchLikelihood::computeNegativeLogLikelihood(
             nll += 0.5 * (std::log(h_t) + (eps_t * eps_t) / h_t);
         }
     } else {  // StudentT
-        // Student-t distribution: Use specialized log-likelihood
+        // Student-t distribution. The df-only constant terms factor out of
+        // the inner loop and are far from free (two lgamma calls); compute
+        // them once.
+        const double df_minus_2 = df - 2.0;
+        const double half_df_plus_1 = (df + 1.0) / 2.0;
+        const double df_constant = -std::lgamma(half_df_plus_1) + std::lgamma(df / 2.0) +
+                                   0.5 * std::log(std::numbers::pi * df_minus_2);
+
         for (std::size_t t = 0; t < residuals.size(); ++t) {
             double eps_t = residuals[t];
             double h_t = conditional_variances[t];
 
-            // Guard against non-positive variance
             if (h_t <= 0.0) {
                 throw std::runtime_error("Conditional variance must be positive");
             }
 
-            nll += studentTLogLikelihood(eps_t, h_t, df);
+            const double standardized_sq = (eps_t * eps_t) / (df_minus_2 * h_t);
+            nll += df_constant + 0.5 * std::log(h_t) + half_df_plus_1 * std::log1p(standardized_sq);
         }
     }
 
     return nll;
-}
-
-double ArimaGarchLikelihood::studentTLogLikelihood(double residual, double variance,
-                                                   double df) const {
-    // Student-t log-likelihood contribution (negative)
-    // -log L = -log(Γ((df+1)/2)) + log(Γ(df/2)) + 0.5*log(π*(df-2)*h_t)
-    //          + 0.5*(df+1)*log(1 + ε_t²/((df-2)*h_t))
-    //
-    // Simplifying by factoring out constant terms that depend only on df:
-    // C(df) = -log(Γ((df+1)/2)) + log(Γ(df/2)) + 0.5*log(π*(df-2))
-    //
-    // Per-observation contribution:
-    // -log L_t = C(df) + 0.5*log(h_t) + 0.5*(df+1)*log(1 + ε_t²/((df-2)*h_t))
-
-    const double df_minus_2 = df - 2.0;
-    const double scaled_variance = df_minus_2 * variance;
-    const double standardized_sq = (residual * residual) / scaled_variance;
-
-    // Compute constant term (depends only on df, could be cached for efficiency)
-    // C(df) = -lgamma((df+1)/2) + lgamma(df/2) + 0.5*log(π*(df-2))
-    const double constant = -std::lgamma((df + 1.0) / 2.0) + std::lgamma(df / 2.0) +
-                            0.5 * std::log(std::numbers::pi * df_minus_2);
-
-    // Per-observation contribution
-    const double nll_t =
-        constant + 0.5 * std::log(variance) + 0.5 * (df + 1.0) * std::log1p(standardized_sq);
-
-    return nll_t;
 }
 
 }  // namespace ag::estimation

--- a/src/estimation/Optimizer.cpp
+++ b/src/estimation/Optimizer.cpp
@@ -159,110 +159,114 @@ void NelderMeadOptimizer::shrink(std::vector<std::vector<double>>& simplex,
     }
 }
 
+namespace {
+
+// Sort simplex vertices in-place by ascending objective value, keeping
+// vertex coordinates and their corresponding objective values aligned.
+void sortSimplexByValue(std::vector<std::vector<double>>& simplex,
+                        std::vector<double>& simplex_values) {
+    const std::size_t n_vertices = simplex.size();
+    std::vector<std::size_t> indices(n_vertices);
+    for (std::size_t i = 0; i < n_vertices; ++i) {
+        indices[i] = i;
+    }
+    std::sort(indices.begin(), indices.end(), [&simplex_values](std::size_t a, std::size_t b) {
+        return simplex_values[a] < simplex_values[b];
+    });
+
+    std::vector<std::vector<double>> sorted_simplex(n_vertices);
+    std::vector<double> sorted_values(n_vertices);
+    for (std::size_t i = 0; i < n_vertices; ++i) {
+        sorted_simplex[i] = std::move(simplex[indices[i]]);
+        sorted_values[i] = simplex_values[indices[i]];
+    }
+    simplex = std::move(sorted_simplex);
+    simplex_values = std::move(sorted_values);
+}
+
+}  // namespace
+
+void NelderMeadOptimizer::stepSimplex(std::vector<std::vector<double>>& simplex,
+                                      std::vector<double>& simplex_values,
+                                      const ObjectiveFunction& objective) const {
+    const std::size_t n_vertices = simplex.size();
+    const std::vector<double> centroid = computeCentroid(simplex);
+
+    // Reflection
+    std::vector<double> reflected = reflect(centroid, simplex.back());
+    const double f_reflected = objective(reflected);
+
+    if (f_reflected < simplex_values[n_vertices - 2] && f_reflected >= simplex_values[0]) {
+        // Reflected point is better than second worst, but not the new best:
+        // accept it.
+        simplex.back() = std::move(reflected);
+        simplex_values.back() = f_reflected;
+        return;
+    }
+
+    if (f_reflected < simplex_values[0]) {
+        // Reflected point is the new best: try to push further (expansion).
+        std::vector<double> expanded = expand(centroid, reflected);
+        const double f_expanded = objective(expanded);
+        if (f_expanded < f_reflected) {
+            simplex.back() = std::move(expanded);
+            simplex_values.back() = f_expanded;
+        } else {
+            simplex.back() = std::move(reflected);
+            simplex_values.back() = f_reflected;
+        }
+        return;
+    }
+
+    // Reflection failed: try contraction.
+    std::vector<double> contracted = contract(centroid, simplex.back());
+    const double f_contracted = objective(contracted);
+    if (f_contracted < simplex_values.back()) {
+        simplex.back() = std::move(contracted);
+        simplex_values.back() = f_contracted;
+        return;
+    }
+
+    // Contraction also failed: shrink simplex toward the best vertex and
+    // re-evaluate the moved vertices.
+    shrink(simplex, simplex[0]);
+    for (std::size_t i = 1; i < n_vertices; ++i) {
+        simplex_values[i] = objective(simplex[i]);
+    }
+}
+
 OptimizationResult NelderMeadOptimizer::minimize(const ObjectiveFunction& objective,
                                                  const std::vector<double>& initial_params) {
     if (initial_params.empty()) {
         throw std::invalid_argument("Initial parameter vector cannot be empty");
     }
 
-    // Initialize simplex
     std::vector<std::vector<double>> simplex = initializeSimplex(initial_params);
     const std::size_t n_vertices = simplex.size();
 
-    // Evaluate objective at all simplex vertices
     std::vector<double> simplex_values(n_vertices);
     for (std::size_t i = 0; i < n_vertices; ++i) {
         simplex_values[i] = objective(simplex[i]);
     }
 
-    // Main optimization loop
     int iteration = 0;
     bool converged = false;
-
     while (iteration < max_iterations_) {
-        // Sort simplex by objective value (best to worst)
-        std::vector<std::size_t> indices(n_vertices);
-        for (std::size_t i = 0; i < n_vertices; ++i) {
-            indices[i] = i;
-        }
-        std::sort(indices.begin(), indices.end(), [&simplex_values](std::size_t a, std::size_t b) {
-            return simplex_values[a] < simplex_values[b];
-        });
-
-        // Reorder simplex and values
-        std::vector<std::vector<double>> sorted_simplex(n_vertices);
-        std::vector<double> sorted_values(n_vertices);
-        for (std::size_t i = 0; i < n_vertices; ++i) {
-            sorted_simplex[i] = simplex[indices[i]];
-            sorted_values[i] = simplex_values[indices[i]];
-        }
-        simplex = sorted_simplex;
-        simplex_values = sorted_values;
-
-        // Check convergence
+        sortSimplexByValue(simplex, simplex_values);
         if (hasConverged(simplex_values, simplex)) {
             converged = true;
             break;
         }
-
-        // Compute centroid of all points except worst
-        std::vector<double> centroid = computeCentroid(simplex);
-
-        // Try reflection
-        std::vector<double> reflected = reflect(centroid, simplex.back());
-        double f_reflected = objective(reflected);
-
-        if (f_reflected < simplex_values[n_vertices - 2] && f_reflected >= simplex_values[0]) {
-            // Reflected point is better than second worst but not better than best
-            simplex.back() = reflected;
-            simplex_values.back() = f_reflected;
-        } else if (f_reflected < simplex_values[0]) {
-            // Reflected point is best so far, try expansion
-            std::vector<double> expanded = expand(centroid, reflected);
-            double f_expanded = objective(expanded);
-
-            if (f_expanded < f_reflected) {
-                simplex.back() = expanded;
-                simplex_values.back() = f_expanded;
-            } else {
-                simplex.back() = reflected;
-                simplex_values.back() = f_reflected;
-            }
-        } else {
-            // Reflected point is worse than second worst, try contraction
-            std::vector<double> contracted = contract(centroid, simplex.back());
-            double f_contracted = objective(contracted);
-
-            if (f_contracted < simplex_values.back()) {
-                simplex.back() = contracted;
-                simplex_values.back() = f_contracted;
-            } else {
-                // Contraction failed, shrink simplex
-                shrink(simplex, simplex[0]);
-
-                // Re-evaluate all vertices except best
-                for (std::size_t i = 1; i < n_vertices; ++i) {
-                    simplex_values[i] = objective(simplex[i]);
-                }
-            }
-        }
-
+        stepSimplex(simplex, simplex_values, objective);
         ++iteration;
     }
 
-    // Prepare result
     OptimizationResult result;
     result.parameters = simplex[0];
     result.objective_value = simplex_values[0];
     result.converged = converged;
     result.iterations = iteration;
-
-    if (converged) {
-        result.message = "Converged";
-    } else {
-        result.message = "Maximum iterations reached";
-    }
-
+    result.message = converged ? "Converged" : "Maximum iterations reached";
     return result;
 }
 

--- a/src/estimation/ParameterInitialization.cpp
+++ b/src/estimation/ParameterInitialization.cpp
@@ -3,6 +3,7 @@
 #include "ag/stats/ACF.hpp"
 #include "ag/stats/Descriptive.hpp"
 #include "ag/stats/PACF.hpp"
+#include "ag/util/Differencing.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -37,25 +38,6 @@ double computeVariance(const double* data, std::size_t size) {
     return sum_sq / static_cast<double>(size - 1);
 }
 
-// Apply differencing to data
-std::vector<double> difference(const double* data, std::size_t size, int d) {
-    std::vector<double> result(data, data + size);
-
-    for (int order = 0; order < d; ++order) {
-        if (result.size() < 2) {
-            break;  // Can't difference anymore
-        }
-        std::vector<double> diff;
-        diff.reserve(result.size() - 1);
-        for (std::size_t i = 1; i < result.size(); ++i) {
-            diff.push_back(result[i] - result[i - 1]);
-        }
-        result = std::move(diff);
-    }
-
-    return result;
-}
-
 }  // namespace
 
 ag::models::arima::ArimaParameters initializeArimaParameters(const double* data, std::size_t size,
@@ -77,7 +59,7 @@ ag::models::arima::ArimaParameters initializeArimaParameters(const double* data,
     // Apply differencing if needed
     std::vector<double> working_data;
     if (d > 0) {
-        working_data = difference(data, size, d);
+        working_data = ag::util::differenceSeries(data, size, d);
         if (working_data.size() < 10) {
             throw std::invalid_argument("Insufficient data after differencing");
         }

--- a/src/estimation/ParameterVector.cpp
+++ b/src/estimation/ParameterVector.cpp
@@ -1,0 +1,87 @@
+#include "ag/estimation/ParameterVector.hpp"
+
+#include <stdexcept>
+#include <string>
+
+namespace ag::estimation::param_vector {
+
+std::size_t size(const ag::models::ArimaGarchSpec& spec) noexcept {
+    std::size_t n = 0;
+    if (!spec.arimaSpec.isZeroOrder()) {
+        n += 1;  // intercept
+        n += static_cast<std::size_t>(spec.arimaSpec.p);
+        n += static_cast<std::size_t>(spec.arimaSpec.q);
+    }
+    if (!spec.garchSpec.isNull()) {
+        n += 1;                                           // omega
+        n += static_cast<std::size_t>(spec.garchSpec.q);  // alpha
+        n += static_cast<std::size_t>(spec.garchSpec.p);  // beta
+    }
+    return n;
+}
+
+std::vector<double> pack(const ag::models::ArimaGarchSpec& spec,
+                         const ag::models::arima::ArimaParameters& arima_params,
+                         const ag::models::garch::GarchParameters& garch_params) {
+    std::vector<double> out;
+    out.reserve(size(spec));
+
+    if (!spec.arimaSpec.isZeroOrder()) {
+        out.push_back(arima_params.intercept);
+        for (int i = 0; i < spec.arimaSpec.p; ++i) {
+            out.push_back(arima_params.ar_coef[i]);
+        }
+        for (int i = 0; i < spec.arimaSpec.q; ++i) {
+            out.push_back(arima_params.ma_coef[i]);
+        }
+    }
+
+    if (!spec.garchSpec.isNull()) {
+        out.push_back(garch_params.omega);
+        for (int i = 0; i < spec.garchSpec.q; ++i) {
+            out.push_back(garch_params.alpha_coef[i]);
+        }
+        for (int i = 0; i < spec.garchSpec.p; ++i) {
+            out.push_back(garch_params.beta_coef[i]);
+        }
+    }
+
+    return out;
+}
+
+void unpack(const std::vector<double>& params, const ag::models::ArimaGarchSpec& spec,
+            ag::models::arima::ArimaParameters& out_arima,
+            ag::models::garch::GarchParameters& out_garch) {
+    const std::size_t expected = size(spec);
+    if (params.size() != expected) {
+        throw std::invalid_argument("param_vector::unpack: vector has " +
+                                    std::to_string(params.size()) + " entries but spec requires " +
+                                    std::to_string(expected));
+    }
+
+    std::size_t idx = 0;
+
+    if (!spec.arimaSpec.isZeroOrder()) {
+        out_arima.intercept = params[idx++];
+        for (int i = 0; i < spec.arimaSpec.p; ++i) {
+            out_arima.ar_coef[i] = params[idx++];
+        }
+        for (int i = 0; i < spec.arimaSpec.q; ++i) {
+            out_arima.ma_coef[i] = params[idx++];
+        }
+    } else {
+        out_arima.intercept = 0.0;
+    }
+
+    if (!spec.garchSpec.isNull()) {
+        out_garch.omega = params[idx++];
+        for (int i = 0; i < spec.garchSpec.q; ++i) {
+            out_garch.alpha_coef[i] = params[idx++];
+        }
+        for (int i = 0; i < spec.garchSpec.p; ++i) {
+            out_garch.beta_coef[i] = params[idx++];
+        }
+    }
+}
+
+}  // namespace ag::estimation::param_vector

--- a/src/forecasting/Forecaster.cpp
+++ b/src/forecasting/Forecaster.cpp
@@ -1,13 +1,15 @@
 #include "ag/forecasting/Forecaster.hpp"
 
+#include "ag/util/NumericConstants.hpp"
+
 #include <algorithm>
 #include <stdexcept>
 
 namespace ag::forecasting {
 
 namespace {
-// Minimum variance threshold to guard against numerical issues
-constexpr double MIN_VARIANCE = 1e-10;
+// Alias the shared variance floor so call sites in this file stay readable.
+constexpr double MIN_VARIANCE = ag::util::MIN_VARIANCE;
 }  // namespace
 
 Forecaster::Forecaster(const ag::models::composite::ArimaGarchModel& model) : model_(model) {}

--- a/src/models/arima/ArimaState.cpp
+++ b/src/models/arima/ArimaState.cpp
@@ -1,6 +1,8 @@
 #include "ag/models/arima/ArimaState.hpp"
 
-#include <algorithm>
+#include "ag/util/Differencing.hpp"
+#include "ag/util/SlidingWindow.hpp"
+
 #include <stdexcept>
 
 namespace ag::models::arima {
@@ -50,40 +52,12 @@ void ArimaState::initialize(const double* data, std::size_t size) {
 }
 
 void ArimaState::update(double observation, double residual) {
-    // Update observation history (shift left and add new)
-    if (p_ > 0) {
-        std::shift_left(obs_history_.begin(), obs_history_.end(), 1);
-        obs_history_.back() = observation;
-    }
-
-    // Update residual history (shift left and add new)
-    if (q_ > 0) {
-        std::shift_left(residual_history_.begin(), residual_history_.end(), 1);
-        residual_history_.back() = residual;
-    }
+    ag::util::shiftAndAppend(obs_history_, observation);
+    ag::util::shiftAndAppend(residual_history_, residual);
 }
 
 std::vector<double> ArimaState::applyDifferencing(const double* data, std::size_t size) const {
-    if (d_ == 0) {
-        return std::vector<double>(data, data + size);
-    }
-
-    std::vector<double> result(data, data + size);
-    std::vector<double> temp;
-
-    // Apply differencing d times
-    for (int order = 0; order < d_; ++order) {
-        temp.clear();
-        temp.reserve(result.size() - 1);
-
-        for (std::size_t i = 1; i < result.size(); ++i) {
-            temp.push_back(result[i] - result[i - 1]);
-        }
-
-        result = std::move(temp);
-    }
-
-    return result;
+    return ag::util::differenceSeries(data, size, d_);
 }
 
 }  // namespace ag::models::arima

--- a/src/models/composite/ArimaGarchModel.cpp
+++ b/src/models/composite/ArimaGarchModel.cpp
@@ -1,5 +1,8 @@
 #include "ag/models/composite/ArimaGarchModel.hpp"
 
+#include "ag/util/NumericConstants.hpp"
+
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -79,53 +82,16 @@ ArimaGarchOutput ArimaGarchModel::predict() const {
 }
 
 double ArimaGarchModel::computeConditionalMean() const {
-    double mean = params_.arima_params.intercept;
-
-    // Add AR component: φ₁*y_{t-1} + φ₂*y_{t-2} + ... + φₚ*y_{t-p}
-    const auto& obs_history = mean_state_.getObservationHistory();
-    for (int i = 0; i < spec_.arimaSpec.p; ++i) {
-        // History is stored with oldest first, so obs_history[0] is y_{t-p}
-        // and obs_history[p-1] is y_{t-1}
-        mean += params_.arima_params.ar_coef[i] * obs_history[spec_.arimaSpec.p - 1 - i];
-    }
-
-    // Add MA component: θ₁*ε_{t-1} + θ₂*ε_{t-2} + ... + θ_q*ε_{t-q}
-    const auto& residual_history = mean_state_.getResidualHistory();
-    for (int i = 0; i < spec_.arimaSpec.q; ++i) {
-        // History is stored with oldest first, so residual_history[0] is ε_{t-q}
-        // and residual_history[q-1] is ε_{t-1}
-        mean += params_.arima_params.ma_coef[i] * residual_history[spec_.arimaSpec.q - 1 - i];
-    }
-
-    return mean;
+    return arima_model_.computeConditionalMean(mean_state_, params_.arima_params);
 }
 
 double ArimaGarchModel::computeConditionalVariance() const {
     if (spec_.garchSpec.isNull()) {
-        // For ARIMA-only models (no GARCH component), use constant variance
-        // Use the initial variance which is computed from residual sample variance
+        // ARIMA-only models use a constant variance held in the state.
         return var_state_.getInitialVariance();
     }
-
-    // For ARIMA-GARCH models, use GARCH recursion
-    const auto& var_history = var_state_.getVarianceHistory();
-    const auto& sq_res_history = var_state_.getSquaredResidualHistory();
-
-    double h_t = params_.garch_params.omega;
-
-    // Add ARCH component: α₁*ε²_{t-1} + α₂*ε²_{t-2} + ... + α_q*ε²_{t-q}
-    for (int i = 0; i < spec_.garchSpec.q; ++i) {
-        h_t += params_.garch_params.alpha_coef[i] * sq_res_history[spec_.garchSpec.q - 1 - i];
-    }
-
-    // Add GARCH component: β₁*h_{t-1} + β₂*h_{t-2} + ... + βₚ*h_{t-p}
-    for (int i = 0; i < spec_.garchSpec.p; ++i) {
-        h_t += params_.garch_params.beta_coef[i] * var_history[spec_.garchSpec.p - 1 - i];
-    }
-
-    // Ensure h_t > 0 (should be guaranteed by positive parameters, but guard against numerical
-    // issues)
-    return std::max(h_t, 1e-10);
+    return std::max(garch_model_.computeConditionalVariance(var_state_, params_.garch_params),
+                    ag::util::MIN_VARIANCE);
 }
 
 }  // namespace ag::models::composite

--- a/src/models/garch/GarchModel.cpp
+++ b/src/models/garch/GarchModel.cpp
@@ -1,5 +1,7 @@
 #include "ag/models/garch/GarchModel.hpp"
 
+#include "ag/util/NumericConstants.hpp"
+
 #include <cmath>
 #include <numeric>
 #include <stdexcept>
@@ -129,7 +131,7 @@ std::vector<double> GarchModel::computeConditionalVariances(const double* residu
 
         // Ensure h_t > 0 (should be guaranteed by positive parameters, but guard against
         // numerical issues)
-        h_t = std::max(h_t, 1e-10);
+        h_t = std::max(h_t, ag::util::MIN_VARIANCE);
 
         conditional_variances.push_back(h_t);
 

--- a/src/models/garch/GarchState.cpp
+++ b/src/models/garch/GarchState.cpp
@@ -1,5 +1,8 @@
 #include "ag/models/garch/GarchState.hpp"
 
+#include "ag/util/NumericConstants.hpp"
+#include "ag/util/SlidingWindow.hpp"
+
 #include <algorithm>
 #include <cmath>
 #include <numeric>
@@ -57,13 +60,8 @@ void GarchState::initialize(const double* residuals, std::size_t size,
 }
 
 void GarchState::update(double conditional_variance, double squared_residual) {
-    // Update variance history (shift left and add new)
-    std::shift_left(variance_history_.begin(), variance_history_.end(), 1);
-    variance_history_.back() = conditional_variance;
-
-    // Update squared residual history (shift left and add new)
-    std::shift_left(squared_residual_history_.begin(), squared_residual_history_.end(), 1);
-    squared_residual_history_.back() = squared_residual;
+    ag::util::shiftAndAppend(variance_history_, conditional_variance);
+    ag::util::shiftAndAppend(squared_residual_history_, squared_residual);
 }
 
 double GarchState::computeSampleVariance(const double* residuals, std::size_t size) const {
@@ -85,7 +83,7 @@ double GarchState::computeSampleVariance(const double* residuals, std::size_t si
     double variance = sum_sq_diff / static_cast<double>(size - 1);
 
     // Ensure variance is positive (handle numerical issues)
-    return std::max(variance, 1e-10);
+    return std::max(variance, ag::util::MIN_VARIANCE);
 }
 
 }  // namespace ag::models::garch

--- a/src/selection/CrossValidation.cpp
+++ b/src/selection/CrossValidation.cpp
@@ -1,8 +1,6 @@
 #include "ag/selection/CrossValidation.hpp"
 
-#include "ag/estimation/Likelihood.hpp"
-#include "ag/estimation/Optimizer.hpp"
-#include "ag/estimation/ParameterInitialization.hpp"
+#include "ag/estimation/FitDriver.hpp"
 #include "ag/forecasting/Forecaster.hpp"
 #include "ag/models/composite/ArimaGarchModel.hpp"
 
@@ -43,146 +41,28 @@ computeCrossValidationScore(const double* data, std::size_t n_obs,
     // Rolling origin cross-validation
     for (std::size_t window_end = config.min_train_size; window_end < n_obs; ++window_end) {
         try {
-            // Training data: [0, window_end)
             const double* train_data = data;
-            std::size_t train_size = window_end;
+            const std::size_t train_size = window_end;
+            const double actual_value = data[window_end];
 
-            // Test data: data[window_end] (1-step-ahead target)
-            double actual_value = data[window_end];
-
-            // Initialize parameters from training data
-            auto [arima_init, garch_init] =
-                ag::estimation::initializeArimaGarchParameters(train_data, train_size, spec);
-
-            // Create likelihood function
-            ag::estimation::ArimaGarchLikelihood likelihood(spec);
-
-            // Pack parameters into vector for optimization
-            std::vector<double> initial_params;
-
-            // Add ARIMA parameters if not zero-order
-            if (!spec.arimaSpec.isZeroOrder()) {
-                initial_params.push_back(arima_init.intercept);
-                for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                    initial_params.push_back(arima_init.ar_coef[i]);
-                }
-                for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                    initial_params.push_back(arima_init.ma_coef[i]);
-                }
-            }
-
-            // Add GARCH parameters
-            initial_params.push_back(garch_init.omega);
-            for (int i = 0; i < spec.garchSpec.p; ++i) {
-                initial_params.push_back(garch_init.alpha_coef[i]);
-            }
-            for (int i = 0; i < spec.garchSpec.q; ++i) {
-                initial_params.push_back(garch_init.beta_coef[i]);
-            }
-
-            // Define objective function with constraints
-            auto objective = [&](const std::vector<double>& params) -> double {
-                ag::models::arima::ArimaParameters arima_p(spec.arimaSpec.p, spec.arimaSpec.q);
-                ag::models::garch::GarchParameters garch_p(spec.garchSpec.p, spec.garchSpec.q);
-
-                std::size_t idx = 0;
-
-                // Unpack ARIMA parameters if not zero-order
-                if (!spec.arimaSpec.isZeroOrder()) {
-                    arima_p.intercept = params[idx++];
-                    for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                        arima_p.ar_coef[i] = params[idx++];
-                    }
-                    for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                        arima_p.ma_coef[i] = params[idx++];
-                    }
-                }
-
-                // Unpack GARCH parameters
-                garch_p.omega = params[idx++];
-                for (int i = 0; i < spec.garchSpec.p; ++i) {
-                    garch_p.alpha_coef[i] = params[idx++];
-                }
-                for (int i = 0; i < spec.garchSpec.q; ++i) {
-                    garch_p.beta_coef[i] = params[idx++];
-                }
-
-                // Check GARCH constraints
-                if (!garch_p.isPositive() || !garch_p.isStationary()) {
-                    return 1e10;  // Penalty for constraint violation
-                }
-
-                // Compute negative log-likelihood
-                try {
-                    return likelihood.computeNegativeLogLikelihood(train_data, train_size, arima_p,
-                                                                   garch_p);
-                } catch (...) {
-                    return 1e10;  // Penalty for computation errors
-                }
-            };
-
-            // Set up optimizer
-            ag::estimation::NelderMeadOptimizer optimizer(1e-6, 1e-6, 2000);
-
-            // Optimize with random restarts for robustness
-            auto result = ag::estimation::optimizeWithRestarts(optimizer, objective, initial_params,
-                                                               3, 0.15, 42);
-
-            // Check if optimization succeeded
-            if (!result.converged) {
-                // Skip this window if fitting failed
+            auto outcome = ag::estimation::runFit(train_data, train_size, spec);
+            if (!outcome || !outcome->converged) {
                 continue;
             }
 
-            // Unpack optimized parameters
-            ag::models::arima::ArimaParameters fitted_arima(spec.arimaSpec.p, spec.arimaSpec.q);
-            ag::models::garch::GarchParameters fitted_garch(spec.garchSpec.p, spec.garchSpec.q);
-
-            std::size_t idx = 0;
-            if (!spec.arimaSpec.isZeroOrder()) {
-                fitted_arima.intercept = result.parameters[idx++];
-                for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                    fitted_arima.ar_coef[i] = result.parameters[idx++];
-                }
-                for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                    fitted_arima.ma_coef[i] = result.parameters[idx++];
-                }
-            }
-            fitted_garch.omega = result.parameters[idx++];
-            for (int i = 0; i < spec.garchSpec.p; ++i) {
-                fitted_garch.alpha_coef[i] = result.parameters[idx++];
-            }
-            for (int i = 0; i < spec.garchSpec.q; ++i) {
-                fitted_garch.beta_coef[i] = result.parameters[idx++];
-            }
-
-            // Create model with fitted parameters and initialize state
-            ag::models::composite::ArimaGarchParameters params(spec);
-            params.arima_params = fitted_arima;
-            params.garch_params = fitted_garch;
-
-            ag::models::composite::ArimaGarchModel model(spec, params);
-
-            // Initialize model state by processing training data
+            ag::models::composite::ArimaGarchModel model(spec, outcome->parameters);
             for (std::size_t i = 0; i < train_size; ++i) {
                 model.update(train_data[i]);
             }
 
-            // Make 1-step-ahead forecast
             ag::forecasting::Forecaster forecaster(model);
             auto forecast_result = forecaster.forecast(1);
+            const double forecast_value = forecast_result.mean_forecasts[0];
 
-            double forecast_value = forecast_result.mean_forecasts[0];
-
-            // Compute squared error
-            double error = actual_value - forecast_value;
-            double squared_error = error * error;
-
-            sum_squared_errors += squared_error;
-            successful_forecasts++;
-
+            const double error = actual_value - forecast_value;
+            sum_squared_errors += error * error;
+            ++successful_forecasts;
         } catch (...) {
-            // Skip this window if any error occurs
             continue;
         }
     }

--- a/src/selection/ModelSelector.cpp
+++ b/src/selection/ModelSelector.cpp
@@ -1,9 +1,7 @@
 #include "ag/selection/ModelSelector.hpp"
 
 #include "ag/diagnostics/DiagnosticReport.hpp"
-#include "ag/estimation/Likelihood.hpp"
-#include "ag/estimation/Optimizer.hpp"
-#include "ag/estimation/ParameterInitialization.hpp"
+#include "ag/estimation/FitDriver.hpp"
 #include "ag/selection/CrossValidation.hpp"
 #include "ag/selection/InformationCriteria.hpp"
 
@@ -99,12 +97,38 @@ ModelSelector::select(const double* data, std::size_t n_obs,
     return best_result;
 }
 
+namespace {
+
+// Fit @p spec on the full @p data via the shared FitDriver and populate
+// the relevant subset of @p out_summary. Returns true on success.
+bool fitFullDataIntoSummary(const double* data, std::size_t n_obs,
+                            const ag::models::ArimaGarchSpec& spec,
+                            ag::report::FitSummary& out_summary) {
+    auto outcome = ag::estimation::runFit(data, n_obs, spec);
+    if (!outcome || !outcome->converged) {
+        return false;
+    }
+
+    out_summary.parameters = outcome->parameters;
+    out_summary.neg_log_likelihood = outcome->neg_log_likelihood;
+    out_summary.converged = outcome->converged;
+    out_summary.iterations = outcome->iterations;
+    out_summary.message = outcome->message;
+    out_summary.sample_size = n_obs;
+
+    int k = spec.totalParamCount();
+    double log_lik = -outcome->neg_log_likelihood;
+    out_summary.aic = computeAIC(log_lik, k);
+    out_summary.bic = computeBIC(log_lik, k, n_obs);
+    return true;
+}
+
+}  // namespace
+
 std::optional<double> ModelSelector::fitAndScore(const double* data, std::size_t n_obs,
                                                  const ag::models::ArimaGarchSpec& spec,
                                                  ag::report::FitSummary& out_summary) {
-    // If CV criterion, use cross-validation scoring
     if (criterion_ == SelectionCriterion::CV) {
-        // Use 70% of data as minimum training size (common heuristic)
         std::size_t min_train_size = static_cast<std::size_t>(n_obs * 0.7);
         if (min_train_size < 50) {
             min_train_size = std::min(static_cast<std::size_t>(50), n_obs - 10);
@@ -115,241 +139,23 @@ std::optional<double> ModelSelector::fitAndScore(const double* data, std::size_t
 
         CrossValidationConfig cv_config(min_train_size);
         auto cv_result = computeCrossValidationScore(data, n_obs, spec, cv_config);
-
         if (!cv_result.has_value()) {
-            return std::nullopt;  // CV failed
-        }
-
-        // Still need to fit on full data to populate out_summary
-        // (This is needed for the best model's parameters)
-        try {
-            auto [arima_init, garch_init] =
-                ag::estimation::initializeArimaGarchParameters(data, n_obs, spec);
-
-            ag::estimation::ArimaGarchLikelihood likelihood(spec);
-
-            std::vector<double> initial_params;
-            if (!spec.arimaSpec.isZeroOrder()) {
-                initial_params.push_back(arima_init.intercept);
-                for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                    initial_params.push_back(arima_init.ar_coef[i]);
-                }
-                for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                    initial_params.push_back(arima_init.ma_coef[i]);
-                }
-            }
-            initial_params.push_back(garch_init.omega);
-            for (int i = 0; i < spec.garchSpec.p; ++i) {
-                initial_params.push_back(garch_init.alpha_coef[i]);
-            }
-            for (int i = 0; i < spec.garchSpec.q; ++i) {
-                initial_params.push_back(garch_init.beta_coef[i]);
-            }
-
-            auto objective = [&](const std::vector<double>& params) -> double {
-                ag::models::arima::ArimaParameters arima_p(spec.arimaSpec.p, spec.arimaSpec.q);
-                ag::models::garch::GarchParameters garch_p(spec.garchSpec.p, spec.garchSpec.q);
-
-                std::size_t idx = 0;
-                if (!spec.arimaSpec.isZeroOrder()) {
-                    arima_p.intercept = params[idx++];
-                    for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                        arima_p.ar_coef[i] = params[idx++];
-                    }
-                    for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                        arima_p.ma_coef[i] = params[idx++];
-                    }
-                }
-                garch_p.omega = params[idx++];
-                for (int i = 0; i < spec.garchSpec.p; ++i) {
-                    garch_p.alpha_coef[i] = params[idx++];
-                }
-                for (int i = 0; i < spec.garchSpec.q; ++i) {
-                    garch_p.beta_coef[i] = params[idx++];
-                }
-
-                if (!garch_p.isPositive() || !garch_p.isStationary()) {
-                    return 1e10;
-                }
-
-                try {
-                    return likelihood.computeNegativeLogLikelihood(data, n_obs, arima_p, garch_p);
-                } catch (...) {
-                    return 1e10;
-                }
-            };
-
-            ag::estimation::NelderMeadOptimizer optimizer(1e-6, 1e-6, 2000);
-            auto result = ag::estimation::optimizeWithRestarts(optimizer, objective, initial_params,
-                                                               3, 0.15, 42);
-
-            if (!result.converged) {
-                return std::nullopt;
-            }
-
-            // Unpack parameters into FitSummary
-            std::size_t idx = 0;
-            if (!spec.arimaSpec.isZeroOrder()) {
-                out_summary.parameters.arima_params.intercept = result.parameters[idx++];
-                for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                    out_summary.parameters.arima_params.ar_coef[i] = result.parameters[idx++];
-                }
-                for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                    out_summary.parameters.arima_params.ma_coef[i] = result.parameters[idx++];
-                }
-            }
-            out_summary.parameters.garch_params.omega = result.parameters[idx++];
-            for (int i = 0; i < spec.garchSpec.p; ++i) {
-                out_summary.parameters.garch_params.alpha_coef[i] = result.parameters[idx++];
-            }
-            for (int i = 0; i < spec.garchSpec.q; ++i) {
-                out_summary.parameters.garch_params.beta_coef[i] = result.parameters[idx++];
-            }
-
-            out_summary.neg_log_likelihood = result.objective_value;
-            out_summary.converged = result.converged;
-            out_summary.iterations = result.iterations;
-            out_summary.message = result.message;
-            out_summary.sample_size = n_obs;
-
-            int k = spec.totalParamCount();
-            double log_lik = -result.objective_value;
-            out_summary.aic = computeAIC(log_lik, k);
-            out_summary.bic = computeBIC(log_lik, k, n_obs);
-
-        } catch (...) {
-            // If full data fit fails, we still have CV score but no parameters
-            // Return nullopt to indicate this candidate failed
             return std::nullopt;
         }
 
-        // Return the CV MSE score
+        // We still fit on the full data to populate out_summary so the
+        // selector can return parameters for the chosen model.
+        if (!fitFullDataIntoSummary(data, n_obs, spec, out_summary)) {
+            return std::nullopt;
+        }
         return cv_result->mse;
     }
 
-    // IC-based selection (original code)
-    try {
-        // Initialize parameters from data
-        auto [arima_init, garch_init] =
-            ag::estimation::initializeArimaGarchParameters(data, n_obs, spec);
-
-        // Create likelihood function
-        ag::estimation::ArimaGarchLikelihood likelihood(spec);
-
-        // Pack parameters into vector for optimization
-        std::vector<double> initial_params;
-
-        // Add ARIMA parameters if not zero-order
-        if (!spec.arimaSpec.isZeroOrder()) {
-            initial_params.push_back(arima_init.intercept);
-            for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                initial_params.push_back(arima_init.ar_coef[i]);
-            }
-            for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                initial_params.push_back(arima_init.ma_coef[i]);
-            }
-        }
-
-        // Add GARCH parameters
-        initial_params.push_back(garch_init.omega);
-        for (int i = 0; i < spec.garchSpec.p; ++i) {
-            initial_params.push_back(garch_init.alpha_coef[i]);
-        }
-        for (int i = 0; i < spec.garchSpec.q; ++i) {
-            initial_params.push_back(garch_init.beta_coef[i]);
-        }
-
-        // Define objective function with constraints
-        auto objective = [&](const std::vector<double>& params) -> double {
-            ag::models::arima::ArimaParameters arima_p(spec.arimaSpec.p, spec.arimaSpec.q);
-            ag::models::garch::GarchParameters garch_p(spec.garchSpec.p, spec.garchSpec.q);
-
-            std::size_t idx = 0;
-
-            // Unpack ARIMA parameters if not zero-order
-            if (!spec.arimaSpec.isZeroOrder()) {
-                arima_p.intercept = params[idx++];
-                for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                    arima_p.ar_coef[i] = params[idx++];
-                }
-                for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                    arima_p.ma_coef[i] = params[idx++];
-                }
-            }
-
-            // Unpack GARCH parameters
-            garch_p.omega = params[idx++];
-            for (int i = 0; i < spec.garchSpec.p; ++i) {
-                garch_p.alpha_coef[i] = params[idx++];
-            }
-            for (int i = 0; i < spec.garchSpec.q; ++i) {
-                garch_p.beta_coef[i] = params[idx++];
-            }
-
-            // Check GARCH constraints
-            if (!garch_p.isPositive() || !garch_p.isStationary()) {
-                return 1e10;  // Penalty for constraint violation
-            }
-
-            // Compute negative log-likelihood
-            try {
-                return likelihood.computeNegativeLogLikelihood(data, n_obs, arima_p, garch_p);
-            } catch (...) {
-                return 1e10;  // Penalty for computation errors
-            }
-        };
-
-        // Set up optimizer with standard settings
-        ag::estimation::NelderMeadOptimizer optimizer(1e-6, 1e-6, 2000);
-
-        // Optimize with random restarts for robustness
-        auto result =
-            ag::estimation::optimizeWithRestarts(optimizer, objective, initial_params, 3, 0.15, 42);
-
-        // Check if optimization succeeded
-        if (!result.converged) {
-            return std::nullopt;  // Failed to converge
-        }
-
-        // Unpack optimized parameters into FitSummary
-        std::size_t idx = 0;
-        if (!spec.arimaSpec.isZeroOrder()) {
-            out_summary.parameters.arima_params.intercept = result.parameters[idx++];
-            for (int i = 0; i < spec.arimaSpec.p; ++i) {
-                out_summary.parameters.arima_params.ar_coef[i] = result.parameters[idx++];
-            }
-            for (int i = 0; i < spec.arimaSpec.q; ++i) {
-                out_summary.parameters.arima_params.ma_coef[i] = result.parameters[idx++];
-            }
-        }
-        out_summary.parameters.garch_params.omega = result.parameters[idx++];
-        for (int i = 0; i < spec.garchSpec.p; ++i) {
-            out_summary.parameters.garch_params.alpha_coef[i] = result.parameters[idx++];
-        }
-        for (int i = 0; i < spec.garchSpec.q; ++i) {
-            out_summary.parameters.garch_params.beta_coef[i] = result.parameters[idx++];
-        }
-
-        // Populate FitSummary
-        out_summary.neg_log_likelihood = result.objective_value;
-        out_summary.converged = result.converged;
-        out_summary.iterations = result.iterations;
-        out_summary.message = result.message;
-        out_summary.sample_size = n_obs;
-
-        // Compute information criteria
-        int k = spec.totalParamCount();
-        double log_lik = -result.objective_value;  // Convert NLL to log-likelihood
-        out_summary.aic = computeAIC(log_lik, k);
-        out_summary.bic = computeBIC(log_lik, k, n_obs);
-
-        // Extract and return the score based on selection criterion
-        return extractScore(out_summary);
-
-    } catch (...) {
-        // Any exception during fitting means this candidate failed
+    // IC-based selection: full-data fit IS the scoring step.
+    if (!fitFullDataIntoSummary(data, n_obs, spec, out_summary)) {
         return std::nullopt;
     }
+    return extractScore(out_summary);
 }
 
 double ModelSelector::extractScore(const ag::report::FitSummary& summary) const noexcept {

--- a/src/simulation/ArimaGarchSimulator.cpp
+++ b/src/simulation/ArimaGarchSimulator.cpp
@@ -1,5 +1,7 @@
 #include "ag/simulation/ArimaGarchSimulator.hpp"
 
+#include "ag/util/NumericConstants.hpp"
+
 #include <cmath>
 #include <stdexcept>
 
@@ -72,38 +74,11 @@ SimulationResult ArimaGarchSimulator::simulate(int length, unsigned int seed,
             z_t = innovations.drawStudentT(df.value());
         }
 
-        // Get current states before update
-        const auto& mean_state = model.getArimaState();
-        const auto& var_state = model.getGarchState();
-
-        // Compute conditional mean
-        double mu_t = params_.arima_params.intercept;
-
-        const auto& obs_history = mean_state.getObservationHistory();
-        for (int i = 0; i < spec_.arimaSpec.p; ++i) {
-            mu_t += params_.arima_params.ar_coef[i] * obs_history[spec_.arimaSpec.p - 1 - i];
-        }
-
-        const auto& residual_history = mean_state.getResidualHistory();
-        for (int i = 0; i < spec_.arimaSpec.q; ++i) {
-            mu_t += params_.arima_params.ma_coef[i] * residual_history[spec_.arimaSpec.q - 1 - i];
-        }
-
-        // Compute conditional variance
-        double h_t = params_.garch_params.omega;
-
-        const auto& var_history = var_state.getVarianceHistory();
-        const auto& sq_res_history = var_state.getSquaredResidualHistory();
-
-        for (int i = 0; i < spec_.garchSpec.q; ++i) {
-            h_t += params_.garch_params.alpha_coef[i] * sq_res_history[spec_.garchSpec.q - 1 - i];
-        }
-
-        for (int i = 0; i < spec_.garchSpec.p; ++i) {
-            h_t += params_.garch_params.beta_coef[i] * var_history[spec_.garchSpec.p - 1 - i];
-        }
-
-        h_t = std::max(h_t, 1e-10);  // Ensure positive variance
+        // Compute conditional mean/variance from the model itself rather
+        // than reimplementing the recursion here.
+        const auto pred = model.predict();
+        const double mu_t = pred.mu_t;
+        const double h_t = std::max(pred.h_t, ag::util::MIN_VARIANCE);
 
         // Generate return: y_t = μ_t + sqrt(h_t) * z_t
         double y_t = mu_t + std::sqrt(h_t) * z_t;

--- a/src/util/Differencing.cpp
+++ b/src/util/Differencing.cpp
@@ -1,11 +1,18 @@
 #include "ag/util/Differencing.hpp"
 
+#include <stdexcept>
 #include <utility>
 
 namespace ag::util {
 
 std::vector<double> differenceSeries(const double* data, std::size_t size, int d) {
-    if (size == 0 || data == nullptr) {
+    if (data == nullptr && size > 0) {
+        throw std::invalid_argument("differenceSeries: data is null but size > 0");
+    }
+    if (d < 0) {
+        throw std::invalid_argument("differenceSeries: d must be >= 0");
+    }
+    if (size == 0) {
         return {};
     }
 

--- a/src/util/Differencing.cpp
+++ b/src/util/Differencing.cpp
@@ -1,0 +1,29 @@
+#include "ag/util/Differencing.hpp"
+
+#include <utility>
+
+namespace ag::util {
+
+std::vector<double> differenceSeries(const double* data, std::size_t size, int d) {
+    if (size == 0 || data == nullptr) {
+        return {};
+    }
+
+    std::vector<double> result(data, data + size);
+
+    for (int order = 0; order < d; ++order) {
+        if (result.size() < 2) {
+            return {};
+        }
+        std::vector<double> diff;
+        diff.reserve(result.size() - 1);
+        for (std::size_t i = 1; i < result.size(); ++i) {
+            diff.push_back(result[i] - result[i - 1]);
+        }
+        result = std::move(diff);
+    }
+
+    return result;
+}
+
+}  // namespace ag::util


### PR DESCRIPTION
## Summary

Executes the refactoring recommendations from the design review. The big win is collapsing four near-identical copies of the ARIMA-GARCH fit pipeline (init → pack → optimize → unpack) into a single `estimation::runFit` driver. Net diff: **~1,000 lines removed**, **37/37 test suites still green** on Release and Debug builds.

### High-impact changes
- **`estimation::param_vector::pack/unpack`** — single source of truth for the optimizer's flat parameter vector layout. Previously Engine, ModelSelector (two branches), and CrossValidation each had inline copies of the same loop. The copies had **diverged**: Engine packed the ARIMA intercept unconditionally while Selector/CrossValidation skipped the ARIMA block for zero-order specs, meaning the same `(0,0,0)+(p,q)` spec searched a different parameter space depending on which entry point you used. **The Selector convention is adopted** (skip the ARIMA block when `isZeroOrder()`) — the intercept is degenerate at p=q=0 and was only adding a useless optimization dimension.
- **`estimation::FitDriver` (`runFit`)** — canonical fit pipeline. Engine, ModelSelector, and CrossValidation each shrink from ~100 lines of pack/objective/optimize/unpack to a single `runFit(...)` call.
- **`OptimizerConfig` + `CONSTRAINT_PENALTY`** — replace hard-coded `(1e-6, 1e-6, 2000, 3, 0.15, 1e10)` literals duplicated across four call sites.
- **`InnovationSpec`** — value type bundling `(InnovationDistribution, df)` with validating factories. Replaces the `(bool use_student_t, double df)` pair that was threaded through fit/simulate/diagnostics. The legacy enums are aliased so source-level callers keep compiling.

### Smaller cleanups
- `ag::util::MIN_VARIANCE` — single constant for the `1e-10` variance floor that was duplicated across four files.
- `ag::util::differenceSeries` — replaces identical differencing loops in `ArimaState` and `ParameterInitialization`.
- `ag::util::shiftAndAppend` — three-line helper for the `shift_left + back() = value` pattern shared by both state classes.
- **Composite `ArimaGarchModel`** now delegates `computeConditionalMean` / `computeConditionalVariance` to the sub-models instead of reimplementing the AR/MA/GARCH recursions. The simulator uses `ArimaGarchModel::predict()` for the same reason.
- **Likelihood** — Student-t `lgamma` constant hoisted out of the per-observation loop (the code comment already flagged this as a known efficiency issue).
- **Optimizer** — `NelderMeadOptimizer::minimize` body decomposed into `stepSimplex()` and a local `sortSimplexByValue()` so each reflection / expansion / contraction / shrink step is a named call.
- **`cli/main.cpp`** — split into per-subcommand handler TUs under `src/cli/handlers/`. `main.cpp` is now argument parsing + dispatch only (~190 lines, was 723).

## Behavioral change to be aware of

For `ArimaGarchSpec(0, 0, 0, P, Q)` (i.e. zero-order ARIMA with a GARCH component), `Engine::fit` previously optimized over `(intercept, omega, alpha, beta)` and now optimizes over `(omega, alpha, beta)`. The reported NLL/AIC/BIC for this exact spec family can shift by a small amount because the intercept is no longer a free parameter. ModelSelector / CrossValidation already used this convention, so the divergence is resolved in their favor.

11 existing tests use specs of this shape; all of them continue to pass with the new convention.

## Test plan
- [x] `make BUILD=Release` clean build
- [x] `make BUILD=Release test` — 37/37 test suites pass (~559 individual tests)
- [x] `make debug && make BUILD=Debug test` — 37/37 test suites pass in Debug
- [x] `scripts/check-format.sh` clean
- [x] CLI smoke tests: `ag --version`, `ag --help`, `ag fit -d <csv> -a 1,0,1 -g 1,1`, `ag sim -a 1,0,1 -g 1,1 -n 50 -s 42 -o /tmp/sim.csv`
- [x] `bench_likelihood` runs and reports reasonable throughput (~50M obs/s on small models)

## Diff stat
```
20 files changed, 299 insertions(+), 1365 deletions(-)
```
plus 11 new files implementing the shared utilities and CLI handlers.

https://claude.ai/code/session_012vZPej3de4mqW2nXDLb3Sp


---
_Generated by [Claude Code](https://claude.ai/code/session_012vZPej3de4mqW2nXDLb3Sp)_