### PR TITLE
Guard likelihood against NaN/Inf so the optimizer can't accept a garbage fit (#131)

### DIFF
--- a/src/estimation/FitDriver.cpp
+++ b/src/estimation/FitDriver.cpp
@@ -4,6 +4,7 @@
 #include "ag/estimation/ParameterInitialization.hpp"
 #include "ag/estimation/ParameterVector.hpp"
 
+#include <cmath>
 #include <stdexcept>
 
 namespace ag::estimation {
@@ -13,6 +14,22 @@ std::optional<FitOutcome> runFit(const double* data, std::size_t n,
                                  const FitOptions& options) {
     if (data == nullptr || n == 0) {
         return std::nullopt;
+    }
+
+    // Validate input finiteness once, up front. This must happen outside the
+    // optimizer objective: the objective maps thrown exceptions to
+    // CONSTRAINT_PENALTY, so non-finite data evaluated there would produce a
+    // flat penalty surface that Nelder-Mead can report as "converged" on
+    // garbage parameters. Failing here yields an actionable non-converged
+    // outcome instead.
+    for (std::size_t i = 0; i < n; ++i) {
+        if (!std::isfinite(data[i])) {
+            FitOutcome failure(spec);
+            failure.converged = false;
+            failure.message =
+                "Input data contains non-finite values (NaN or Inf) at index " + std::to_string(i);
+            return failure;
+        }
     }
 
     // Initialize parameters from data. If this throws we return a non-

--- a/src/estimation/Likelihood.cpp
+++ b/src/estimation/Likelihood.cpp
@@ -46,9 +46,11 @@ double ArimaGarchLikelihood::computeNegativeLogLikelihood(
             double eps_t = residuals[t];
             double h_t = conditional_variances[t];
 
-            // Guard against non-positive variance (should not happen with valid parameters)
-            if (h_t <= 0.0) {
-                throw std::runtime_error("Conditional variance must be positive");
+            // Guard against non-positive or non-finite variance. The negated
+            // comparison also rejects NaN (every comparison with NaN is false),
+            // which a bare `h_t <= 0.0` would silently let through.
+            if (!(h_t > 0.0)) {
+                throw std::runtime_error("Conditional variance must be positive and finite");
             }
 
             // Accumulate: 0.5 * (log(h_t) + ε_t² / h_t)
@@ -67,13 +69,23 @@ double ArimaGarchLikelihood::computeNegativeLogLikelihood(
             double eps_t = residuals[t];
             double h_t = conditional_variances[t];
 
-            if (h_t <= 0.0) {
-                throw std::runtime_error("Conditional variance must be positive");
+            if (!(h_t > 0.0)) {
+                throw std::runtime_error("Conditional variance must be positive and finite");
             }
 
             const double standardized_sq = (eps_t * eps_t) / (df_minus_2 * h_t);
             nll += df_constant + 0.5 * std::log(h_t) + half_df_plus_1 * std::log1p(standardized_sq);
         }
+    }
+
+    // A diverging/explosive recursion (or a non-finite residual that slipped
+    // through) can yield a NaN/Inf NLL. Returning it would let Nelder-Mead
+    // treat the vertex as "not worse" (every comparison with NaN is false) and
+    // potentially report convergence on garbage parameters. Throwing here lets
+    // the FitDriver objective map it to CONSTRAINT_PENALTY so the optimizer
+    // steers away consistently.
+    if (!std::isfinite(nll)) {
+        throw std::runtime_error("Negative log-likelihood is not finite");
     }
 
     return nll;

--- a/tests/unit/test_api_engine.cpp
+++ b/tests/unit/test_api_engine.cpp
@@ -7,7 +7,9 @@
 #include <cmath>
 #include <filesystem>
 #include <iostream>
+#include <limits>
 #include <memory>
+#include <string>
 
 #include "test_framework.hpp"
 
@@ -63,6 +65,28 @@ TEST(engine_fit_insufficient_data) {
     auto fit_result = engine.fit(data, spec);
 
     REQUIRE(!fit_result.has_value());
+}
+
+TEST(engine_fit_nonfinite_data_fails_cleanly) {
+    // Data with a NaN (and an Inf) must not produce a "successful" converged
+    // fit built on non-finite parameters; it should fail with an actionable
+    // message. Regression test for the NaN/Inf likelihood guard.
+    ArimaGarchSpec spec(1, 0, 1, 1, 1);
+
+    std::vector<double> nan_data(50, 0.1);
+    nan_data[25] = std::numeric_limits<double>::quiet_NaN();
+
+    Engine engine;
+    auto fit_nan = engine.fit(nan_data, spec);
+    REQUIRE(!fit_nan.has_value());
+    REQUIRE(fit_nan.error().message.find("non-finite") != std::string::npos);
+
+    std::vector<double> inf_data(50, 0.1);
+    inf_data[10] = std::numeric_limits<double>::infinity();
+
+    auto fit_inf = engine.fit(inf_data, spec);
+    REQUIRE(!fit_inf.has_value());
+    REQUIRE(fit_inf.error().message.find("non-finite") != std::string::npos);
 }
 
 TEST(engine_fit_no_diagnostics) {


### PR DESCRIPTION
## Summary

Fixes #131.

`computeNegativeLogLikelihood` only guarded `h_t <= 0.0`. A `NaN` conditional variance (from a diverging/explosive recursion or non-finite input) fails that test — every comparison with `NaN` is false — so the loop accumulated a `NaN` NLL and returned it. Nelder–Mead then treats such a vertex as "not worse" (again, `NaN` comparisons are false) and can terminate reporting `converged = true` on meaningless parameters, which `Engine::fit` surfaces as a successful fit.

## Changes

- `src/estimation/Likelihood.cpp`
  - Replace `if (h_t <= 0.0)` with `if (!(h_t > 0.0))` in both the Normal and Student-t loops, so a `NaN` (or non-positive) variance is rejected as infeasible.
  - After accumulation, `throw` if the NLL is not finite. `FitDriver`'s objective already maps thrown exceptions to `CONSTRAINT_PENALTY`, so the optimizer steers away consistently — closing the remaining hole noted in the issue.
- `src/estimation/FitDriver.cpp`
  - Validate input-data finiteness **once, up front** in `runFit`, *outside* the penalty-catching objective. Doing it inside the objective would just produce a flat penalty surface that Nelder–Mead can report as "converged"; doing it up front yields an actionable non-converged outcome (`Input data contains non-finite values …`).
- `tests/unit/test_api_engine.cpp`
  - New `engine_fit_nonfinite_data_fails_cleanly` test feeding `NaN` and `Inf` data and asserting the fit fails with a "non-finite" message.

### Note on placement
The issue suggested validating at the entry of `computeResiduals`/`computeConditionalVariances`. I deliberately put the *input* check in `runFit` instead: those functions are called once per optimizer evaluation, so an O(n) scan there would be repeated work, and a throw there is swallowed into `CONSTRAINT_PENALTY` (no actionable message). The in-loop `!(h_t > 0.0)` and final `isfinite(nll)` guards still cover the diverging-recursion case during optimization.

## Verification
- Full build green; `ctest` 37/37 pass (including the new test).
- `clang-format --dry-run --Werror` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_