### PR TITLE
Fit the ADF regression for automatic lag selection (#130)

### DIFF
--- a/src/stats/ADF.cpp
+++ b/src/stats/ADF.cpp
@@ -181,9 +181,40 @@ double compute_ols_tstat(const std::vector<double>& y, const std::vector<std::ve
 }
 
 /**
+ * @brief Residual sum of squares of the OLS fit of y on X.
+ *
+ * Fits β̂ = (X'X)⁻¹X'y and returns Σ(y - Xβ̂)². Returns +∞ if the system is
+ * singular so the caller can skip that specification.
+ *
+ * @param y Response vector
+ * @param X Design matrix (row-major)
+ * @return Residual sum of squares, or +∞ on a singular system
+ */
+double compute_ols_rss(const std::vector<double>& y, const std::vector<std::vector<double>>& X) {
+    std::vector<double> beta = ag::util::solveLeastSquares(X, y, 1e-12);
+    if (beta.empty()) {
+        return std::numeric_limits<double>::infinity();
+    }
+
+    const std::size_t n = y.size();
+    const std::size_t k = X[0].size();
+    double rss = 0.0;
+    for (std::size_t t = 0; t < n; ++t) {
+        double fitted = 0.0;
+        for (std::size_t i = 0; i < k; ++i) {
+            fitted += X[t][i] * beta[i];
+        }
+        const double resid = y[t] - fitted;
+        rss += resid * resid;
+    }
+    return rss;
+}
+
+/**
  * @brief Automatically select number of lags using information criterion.
  *
- * Uses modified AIC (MAIC) for lag selection.
+ * Uses AIC computed from the actual OLS residual sum of squares for lag
+ * selection.
  *
  * @param data Time series data
  * @param max_lags Maximum lags to consider
@@ -253,20 +284,17 @@ std::size_t select_lags(std::span<const double> data, std::size_t max_lags,
             X.push_back(row);
         }
 
-        // Compute RSS for this specification
+        // Compute RSS for this specification by actually fitting the ADF
+        // regression. Scoring the information criterion off the (lag-invariant)
+        // variance of Δy made the IC monotone in the parameter penalty and
+        // therefore always selected lag 0.
         try {
-            // NOTE: For computational efficiency, we use a simplified RSS approximation
-            // based on the variance of the dependent variable rather than fitting
-            // the full regression. This provides a reasonable heuristic for lag selection
-            // while avoiding the computational cost of repeated OLS fits.
-            // A more sophisticated implementation could use actual regression fits.
-            double y_mean = std::accumulate(y.begin(), y.end(), 0.0) / y.size();
-            double rss = 0.0;
-            for (const auto& val : y) {
-                rss += (val - y_mean) * (val - y_mean);
+            double rss = compute_ols_rss(y, X);
+            if (!std::isfinite(rss) || rss <= 0.0) {
+                continue;  // Singular/degenerate fit for this lag; skip.
             }
 
-            // Modified AIC
+            // AIC from the real residual sum of squares.
             double ic = std::log(rss / n_obs) + 2.0 * k_total / n_obs;
 
             if (ic < best_ic) {

--- a/tests/unit/test_stats_adf.cpp
+++ b/tests/unit/test_stats_adf.cpp
@@ -152,6 +152,32 @@ TEST(adf_test_auto_lag_selection) {
     REQUIRE(result.p_value <= 1.0);
 }
 
+// Auto lag selection must respond to autocorrelation in the differences.
+// Here Δy follows an AR(1) with strong persistence, so including lagged
+// differences materially lowers the regression RSS and AIC should prefer a
+// non-zero lag. The previous variance-of-Δy shortcut always returned lag 0.
+TEST(adf_test_auto_lag_selects_nonzero_with_ar_differences) {
+    std::mt19937 gen(2024);
+    std::normal_distribution<double> dist(0.0, 1.0);
+
+    const std::size_t n = 400;
+    std::vector<double> data(n);
+    double diff = 0.0;
+    data[0] = 0.0;
+    for (std::size_t t = 1; t < n; ++t) {
+        diff = 0.7 * diff + dist(gen);  // AR(1) differences
+        data[t] = data[t - 1] + diff;
+    }
+
+    auto result = ag::stats::adf_test(data, 0, ag::stats::ADFRegressionForm::Constant);
+
+    // With AR(1) differences, the information criterion should pick at least
+    // one lagged difference rather than collapsing to lag 0.
+    REQUIRE(result.lags >= 1);
+    REQUIRE(result.p_value >= 0.0);
+    REQUIRE(result.p_value <= 1.0);
+}
+
 // Test automatic regression form selection
 TEST(adf_test_auto_regression_form) {
     std::mt19937 gen(666);


### PR DESCRIPTION
## Summary

Fixes #130.

`select_lags` built the full ADF design matrix `X` for each candidate lag, then **discarded `X`** and computed the information criterion from `Var(Δy)` (the variance of the dependent variable). That quantity is essentially lag-invariant, while the `k_total` penalty grows with `p`, so the IC reduced to `argmin log(Var(Δy)) + 2·k_total/n_obs` — monotone in the penalty, always selecting `p = 0`. Automatic lag selection was effectively a constant function, so `adf_test_auto` ran an under-specified regression.

## Changes

- `src/stats/ADF.cpp`
  - New `compute_ols_rss(y, X)` helper that fits the regression via `ag::util::solveLeastSquares` and returns the **true** residual sum of squares (`+∞` on a singular system).
  - `select_lags` now scores AIC off that real RSS and skips degenerate/singular lags, replacing the variance shortcut (the shortcut's own comment acknowledged the approximation).

- `tests/unit/test_stats_adf.cpp`
  - New `adf_test_auto_lag_selects_nonzero_with_ar_differences`: builds a series whose **differences** follow an AR(1) (ρ=0.7). Lagged differences then explain real variance in Δy, so AIC should pick `lags ≥ 1`. Under the old shortcut this returned 0.

## Notes
- This is the path #137 (P2) wants to consolidate to a single OLS t-stat helper; I kept the new helper local and minimal so #137 can do the dedup without conflict.
- `<numeric>` (previously used only by the removed `std::accumulate`) is left included; harmless and avoids touching unrelated lines.

## Verification
- Full build green; `ctest` 37/37 pass including the new test (and all existing ADF tests unchanged).
- `clang-format --dry-run --Werror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_