### PR TITLE
Restore saved model state in loadModel (#129)

### DIFF
--- a/include/ag/models/arima/ArimaState.hpp
+++ b/include/ag/models/arima/ArimaState.hpp
@@ -51,6 +51,25 @@ public:
     void update(double observation, double residual);
 
     /**
+     * @brief Restore the state directly from previously saved histories.
+     *
+     * Used when deserializing a fitted model so that forecasts continue from
+     * the exact terminal state, rather than from a fresh zero-history state.
+     * The histories are the bounded sliding windows the recursion consumes:
+     * @p observation_history must hold p values and @p residual_history q
+     * values (oldest first), matching the orders this state was constructed
+     * with.
+     *
+     * @param observation_history The p most recent observations (oldest first)
+     * @param residual_history The q most recent residuals (oldest first)
+     * @param differenced_series The differenced series (empty when d == 0)
+     * @throws std::invalid_argument if a history size does not match the order
+     */
+    void restore(const std::vector<double>& observation_history,
+                 const std::vector<double>& residual_history,
+                 const std::vector<double>& differenced_series);
+
+    /**
      * @brief Get the historical observations for AR component.
      * @return Vector of the most recent p observations (oldest first)
      */

--- a/include/ag/models/composite/ArimaGarchModel.hpp
+++ b/include/ag/models/composite/ArimaGarchModel.hpp
@@ -100,6 +100,23 @@ public:
     [[nodiscard]] ArimaGarchOutput predict() const;
 
     /**
+     * @brief Restore the internal ARIMA and GARCH states.
+     *
+     * Replaces the fresh zero-history states created by the constructor with
+     * previously saved states (e.g. when deserializing a fitted model), so
+     * that subsequent forecasts continue from the model's terminal state
+     * rather than from zero history. The supplied states must have been built
+     * for the same orders as this model's specification.
+     *
+     * @param arima_state The restored ARIMA state
+     * @param garch_state The restored GARCH state
+     */
+    void restoreState(const arima::ArimaState& arima_state, const garch::GarchState& garch_state) {
+        mean_state_ = arima_state;
+        var_state_ = garch_state;
+    }
+
+    /**
      * @brief Get the ARIMA-GARCH specification for this model.
      * @return The ARIMA-GARCH specification
      */

--- a/include/ag/models/garch/GarchState.hpp
+++ b/include/ag/models/garch/GarchState.hpp
@@ -51,6 +51,24 @@ public:
     void update(double conditional_variance, double squared_residual);
 
     /**
+     * @brief Restore the state directly from previously saved histories.
+     *
+     * Used when deserializing a fitted model so that variance forecasts
+     * continue from the exact terminal state. @p variance_history must hold p
+     * values and @p squared_residual_history q values (oldest first), matching
+     * the orders this state was constructed with. For an ARIMA-only model
+     * (p == q == 0) both histories are empty and only @p initial_variance is
+     * meaningful (it is the constant variance the model returns).
+     *
+     * @param variance_history The p most recent conditional variances
+     * @param squared_residual_history The q most recent squared residuals
+     * @param initial_variance The initial conditional variance h_0
+     * @throws std::invalid_argument if a history size does not match the order
+     */
+    void restore(const std::vector<double>& variance_history,
+                 const std::vector<double>& squared_residual_history, double initial_variance);
+
+    /**
      * @brief Get the historical conditional variances for GARCH component.
      * @return Vector of the most recent p conditional variances (oldest first)
      */

--- a/src/io/Json.cpp
+++ b/src/io/Json.cpp
@@ -260,25 +260,17 @@ JsonReader::arimaStateFromJson(const nlohmann::json& json, const models::ArimaSp
     try {
         models::arima::ArimaState state(spec.p, spec.d, spec.q);
 
-        // We need to reconstruct the state by initializing it with dummy data
-        // and then manually setting the internal state
-        // Since we can't directly set the private members, we'll need to use the public interface
-
-        // First, initialize with dummy data
-        std::vector<double> dummy_data(1, 0.0);
-        state.initialize(dummy_data.data(), dummy_data.size());
-
-        // The state is now initialized, but we need to populate it with the saved histories
-        // We can do this by calling update() with the saved values
+        // Restore the bounded sliding windows directly so the loaded state is
+        // byte-for-byte the terminal state that was saved (replaying through
+        // update() from a dummy-initialized state would not reproduce it).
         auto obs_history = json.at("observation_history").get<std::vector<double>>();
         auto residual_history = json.at("residual_history").get<std::vector<double>>();
-
-        // Update state for each historical observation/residual pair
-        // Note: This is a workaround since we can't directly set private members
-        // We'll update in reverse order to populate the histories correctly
-        for (size_t i = 0; i < obs_history.size() && i < residual_history.size(); ++i) {
-            state.update(obs_history[i], residual_history[i]);
+        std::vector<double> differenced_series;
+        if (json.contains("differenced_series")) {
+            differenced_series = json.at("differenced_series").get<std::vector<double>>();
         }
+
+        state.restore(obs_history, residual_history, differenced_series);
 
         return state;
     } catch (const nlohmann::json::exception& e) {
@@ -293,20 +285,14 @@ JsonReader::garchStateFromJson(const nlohmann::json& json, const models::GarchSp
     try {
         models::garch::GarchState state(spec.p, spec.q);
 
-        // Initialize with dummy data
-        std::vector<double> dummy_residuals(1, 0.0);
+        // Restore the saved histories and initial variance directly (see the
+        // ArimaState helper above for why replaying update() is insufficient).
         double initial_variance = json.at("initial_variance").get<double>();
-        state.initialize(dummy_residuals.data(), dummy_residuals.size(), initial_variance);
-
-        // Populate histories by calling update()
         auto variance_history = json.at("variance_history").get<std::vector<double>>();
         auto squared_residual_history =
             json.at("squared_residual_history").get<std::vector<double>>();
 
-        for (size_t i = 0; i < variance_history.size() && i < squared_residual_history.size();
-             ++i) {
-            state.update(variance_history[i], squared_residual_history[i]);
-        }
+        state.restore(variance_history, squared_residual_history, initial_variance);
 
         return state;
     } catch (const nlohmann::json::exception& e) {
@@ -378,14 +364,24 @@ JsonReader::loadModel(const std::filesystem::path& filepath) {
         // Create model
         models::composite::ArimaGarchModel model(spec, *params_result);
 
-        // Note: The state is initialized in the constructor with dummy data.
-        // For a full round-trip, we would need to either:
-        // 1. Add a method to the model to restore state from saved histories
-        // 2. Accept that the state will be re-initialized when loading
-        //
-        // For now, the loaded model will have fresh state (as if just fitted)
-        // This is acceptable because the parameters are what matter for forecasting.
-        // The state can be rebuilt by processing the original data through update().
+        // Restore the saved state so forecasts continue from the model's
+        // terminal state rather than from a fresh zero-history state. Older
+        // files without a "state" block keep the constructor's fresh state.
+        if (j.contains("state")) {
+            const auto& state_json = j.at("state");
+
+            auto arima_state_result = arimaStateFromJson(state_json.at("arima"), spec.arimaSpec);
+            if (!arima_state_result.has_value()) {
+                return unexpected<JsonError>(arima_state_result.error());
+            }
+
+            auto garch_state_result = garchStateFromJson(state_json.at("garch"), spec.garchSpec);
+            if (!garch_state_result.has_value()) {
+                return unexpected<JsonError>(garch_state_result.error());
+            }
+
+            model.restoreState(*arima_state_result, *garch_state_result);
+        }
 
         return model;
     } catch (const nlohmann::json::exception& e) {

--- a/src/models/arima/ArimaState.cpp
+++ b/src/models/arima/ArimaState.cpp
@@ -56,6 +56,24 @@ void ArimaState::update(double observation, double residual) {
     ag::util::shiftAndAppend(residual_history_, residual);
 }
 
+void ArimaState::restore(const std::vector<double>& observation_history,
+                         const std::vector<double>& residual_history,
+                         const std::vector<double>& differenced_series) {
+    if (observation_history.size() != static_cast<std::size_t>(p_)) {
+        throw std::invalid_argument(
+            "ArimaState::restore: observation history size must equal AR order p");
+    }
+    if (residual_history.size() != static_cast<std::size_t>(q_)) {
+        throw std::invalid_argument(
+            "ArimaState::restore: residual history size must equal MA order q");
+    }
+
+    obs_history_ = observation_history;
+    residual_history_ = residual_history;
+    differenced_series_ = differenced_series;
+    initialized_ = true;
+}
+
 std::vector<double> ArimaState::applyDifferencing(const double* data, std::size_t size) const {
     return ag::util::differenceSeries(data, size, d_);
 }

--- a/src/models/garch/GarchState.cpp
+++ b/src/models/garch/GarchState.cpp
@@ -64,6 +64,24 @@ void GarchState::update(double conditional_variance, double squared_residual) {
     ag::util::shiftAndAppend(squared_residual_history_, squared_residual);
 }
 
+void GarchState::restore(const std::vector<double>& variance_history,
+                         const std::vector<double>& squared_residual_history,
+                         double initial_variance) {
+    if (variance_history.size() != static_cast<std::size_t>(p_)) {
+        throw std::invalid_argument(
+            "GarchState::restore: variance history size must equal GARCH order p");
+    }
+    if (squared_residual_history.size() != static_cast<std::size_t>(q_)) {
+        throw std::invalid_argument(
+            "GarchState::restore: squared residual history size must equal ARCH order q");
+    }
+
+    initial_variance_ = initial_variance;
+    variance_history_ = variance_history;
+    squared_residual_history_ = squared_residual_history;
+    initialized_ = true;
+}
+
 double GarchState::computeSampleVariance(const double* residuals, std::size_t size) const {
     if (size < 2) {
         // Return a small positive value if insufficient data

--- a/tests/unit/test_io_json.cpp
+++ b/tests/unit/test_io_json.cpp
@@ -1,3 +1,4 @@
+#include "ag/forecasting/Forecaster.hpp"
 #include "ag/io/Json.hpp"
 #include "ag/models/ArimaGarchSpec.hpp"
 #include "ag/models/composite/ArimaGarchModel.hpp"
@@ -5,6 +6,7 @@
 #include <cmath>
 #include <filesystem>
 #include <string>
+#include <vector>
 
 #include "test_framework.hpp"
 
@@ -231,7 +233,10 @@ TEST(json_model_save_load_parameters) {
     std::filesystem::remove(model_file);
 }
 
-// Test that saved model produces identical forecasts (via update)
+// Test that a saved model resumes from its terminal state: feeding the same
+// *new* observations to the in-process model and to the reloaded model yields
+// identical outputs. (Previously loadModel discarded state, so a reloaded
+// model restarted from zero history; this test now pins state continuity.)
 TEST(json_model_identical_forecasts) {
     auto model_file = std::filesystem::temp_directory_path() / "test_model_forecast.json";
 
@@ -247,15 +252,10 @@ TEST(json_model_identical_forecasts) {
 
     ArimaGarchModel original_model(spec, params);
 
-    // Generate some observations with original model
-    std::vector<double> test_data = {1.0, 1.5, 1.2, 1.8, 1.3};
-    std::vector<double> original_means;
-    std::vector<double> original_variances;
-
-    for (double y : test_data) {
-        auto output = original_model.update(y);
-        original_means.push_back(output.mu_t);
-        original_variances.push_back(output.h_t);
+    // Warm up the model with some history before saving.
+    std::vector<double> warmup_data = {1.0, 1.5, 1.2, 1.8, 1.3};
+    for (double y : warmup_data) {
+        original_model.update(y);
     }
 
     // Save model after processing
@@ -268,31 +268,87 @@ TEST(json_model_identical_forecasts) {
 
     auto loaded_model = *load_result;
 
-    // Process same data with loaded model
-    std::vector<double> loaded_means;
-    std::vector<double> loaded_variances;
-
-    for (double y : test_data) {
-        auto output = loaded_model.update(y);
-        loaded_means.push_back(output.mu_t);
-        loaded_variances.push_back(output.h_t);
-    }
-
-    // Compare outputs - they should be identical since parameters are the same
-    // Note: State might differ slightly due to initialization, but with same parameters,
-    // the model behavior should converge quickly
-    REQUIRE(loaded_means.size() == original_means.size());
-    REQUIRE(loaded_variances.size() == original_variances.size());
-
-    // Check that parameters produce consistent behavior
-    // (exact state match is not guaranteed due to how state is restored)
-    for (size_t i = 0; i < loaded_means.size(); ++i) {
-        // We use a slightly larger tolerance since state restoration may not be exact
-        REQUIRE(approx_equal(loaded_means[i], original_means[i], 1e-6));
-        REQUIRE(approx_equal(loaded_variances[i], original_variances[i], 1e-6));
+    // Continue both models with the same *new* observations. Because the
+    // loaded model resumed from the saved terminal state, the per-step outputs
+    // must match exactly.
+    std::vector<double> continuation_data = {1.1, 0.7, 1.6, 1.0};
+    for (double y : continuation_data) {
+        auto original_output = original_model.update(y);
+        auto loaded_output = loaded_model.update(y);
+        REQUIRE(approx_equal(loaded_output.mu_t, original_output.mu_t));
+        REQUIRE(approx_equal(loaded_output.h_t, original_output.h_t));
     }
 
     // Cleanup
+    std::filesystem::remove(model_file);
+}
+
+// Saving a model after processing data and loading it must restore the exact
+// terminal state (histories), so a load -> forecast matches an in-process
+// forecast without re-feeding the data. Regression test for loadModel
+// previously discarding state.
+TEST(json_model_state_roundtrip_and_forecast) {
+    auto model_file = std::filesystem::temp_directory_path() / "test_model_state_roundtrip.json";
+
+    ArimaGarchSpec spec(1, 0, 1, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.arima_params.intercept = 0.05;
+    params.arima_params.ar_coef[0] = 0.6;
+    params.arima_params.ma_coef[0] = 0.3;
+    params.garch_params.omega = 0.01;
+    params.garch_params.alpha_coef[0] = 0.1;
+    params.garch_params.beta_coef[0] = 0.85;
+
+    ArimaGarchModel original_model(spec, params);
+    std::vector<double> data = {1.0, 1.5, 1.2, 1.8, 1.3, 0.9, 1.1, 1.4};
+    for (double y : data) {
+        original_model.update(y);
+    }
+
+    auto save_result = JsonWriter::saveModel(model_file, original_model);
+    REQUIRE(save_result.has_value());
+
+    auto load_result = JsonReader::loadModel(model_file);
+    REQUIRE(load_result.has_value());
+    const auto& loaded_model = *load_result;
+
+    // Restored histories must equal the saved ones.
+    const auto& orig_arima = original_model.getArimaState();
+    const auto& load_arima = loaded_model.getArimaState();
+    REQUIRE(load_arima.getObservationHistory().size() == orig_arima.getObservationHistory().size());
+    for (size_t i = 0; i < orig_arima.getObservationHistory().size(); ++i) {
+        REQUIRE(approx_equal(load_arima.getObservationHistory()[i],
+                             orig_arima.getObservationHistory()[i]));
+    }
+    for (size_t i = 0; i < orig_arima.getResidualHistory().size(); ++i) {
+        REQUIRE(
+            approx_equal(load_arima.getResidualHistory()[i], orig_arima.getResidualHistory()[i]));
+    }
+
+    const auto& orig_garch = original_model.getGarchState();
+    const auto& load_garch = loaded_model.getGarchState();
+    REQUIRE(approx_equal(load_garch.getInitialVariance(), orig_garch.getInitialVariance()));
+    for (size_t i = 0; i < orig_garch.getVarianceHistory().size(); ++i) {
+        REQUIRE(
+            approx_equal(load_garch.getVarianceHistory()[i], orig_garch.getVarianceHistory()[i]));
+    }
+    for (size_t i = 0; i < orig_garch.getSquaredResidualHistory().size(); ++i) {
+        REQUIRE(approx_equal(load_garch.getSquaredResidualHistory()[i],
+                             orig_garch.getSquaredResidualHistory()[i]));
+    }
+
+    // Forecasts from the loaded model must match the in-process model exactly.
+    ag::forecasting::Forecaster original_forecaster(original_model);
+    ag::forecasting::Forecaster loaded_forecaster(loaded_model);
+    auto original_fc = original_forecaster.forecast(5);
+    auto loaded_fc = loaded_forecaster.forecast(5);
+
+    REQUIRE(loaded_fc.mean_forecasts.size() == original_fc.mean_forecasts.size());
+    for (size_t h = 0; h < original_fc.mean_forecasts.size(); ++h) {
+        REQUIRE(approx_equal(loaded_fc.mean_forecasts[h], original_fc.mean_forecasts[h]));
+        REQUIRE(approx_equal(loaded_fc.variance_forecasts[h], original_fc.variance_forecasts[h]));
+    }
+
     std::filesystem::remove(model_file);
 }
 


### PR DESCRIPTION
## Summary

Fixes #129.

`JsonWriter` serialized the full model state (observation/residual/variance/squared-residual histories and the GARCH initial variance), but `JsonReader::loadModel` discarded it and kept the constructor's fresh zero-history state — the code comment admitted as much. The `arimaStateFromJson`/`garchStateFromJson` helpers were **dead code**, and they tried to rebuild state by replaying `update()` from a dummy-initialized state, which does *not* reproduce the bounded sliding windows the forecaster consumes. So `ag fit -o model.json` then `ag forecast -m model.json` forecast from zero history (≈ intercept and omega), contradicting the README's reproducibility claim.

## Approach
The forecaster reads exactly four bounded windows (`obs`, `residual`, `variance`, `squared-residual`) plus the GARCH initial variance — all fully serialized. Faithful restoration therefore means assigning those windows **directly**, not replaying `update()`.

## Changes
- `ArimaState::restore(...)` / `GarchState::restore(...)`: assign the saved histories (and GARCH `initial_variance`) directly, validating that each window's size matches the model order.
- `ArimaGarchModel::restoreState(arima_state, garch_state)`: installs restored states over the constructor's fresh ones.
- Rewrote `arimaStateFromJson`/`garchStateFromJson` to use the new `restore` path (no more `update()` replay) and wired `loadModel` to restore state when the JSON has a `"state"` block. Older state-less files still load with fresh state (backward compatible).
- `tests/unit/test_io_json.cpp`:
  - New `json_model_state_roundtrip_and_forecast`: asserts the restored histories equal the saved ones **and** that a reloaded model's `forecast()` matches the in-process model's `forecast()` exactly.
  - Updated `json_model_identical_forecasts`, which previously encoded the *old* fresh-start behavior (re-feeding the same data to a "blank" reloaded model). It now feeds the same **new** observations to both models and asserts identical per-step output — i.e. state continuity.

## Interaction with #128 (differencing)
Restoring the exact saved windows guarantees the reloaded model is on the same scale the forecaster expects, so save→load→forecast equals fit→forecast for the currently-correct `d = 0` path. When #128 makes the composite model `d`-aware, the saved/restored windows remain consistent (this PR doesn't change what `update()` stores).

## Verification
- Full build green; `ctest` 37/37 pass (new test + updated test).
- `clang-format --dry-run --Werror` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_