### PR TITLE
Make the composite ARIMA-GARCH model d-aware and integrate forecasts to levels (#128)

### DIFF
--- a/include/ag/models/composite/ArimaGarchModel.hpp
+++ b/include/ag/models/composite/ArimaGarchModel.hpp
@@ -126,6 +126,19 @@ public:
     }
 
     /**
+     * @brief Restore the differencing anchors (for d > 0 models).
+     *
+     * Used when deserializing a fitted model so that forecasts integrate from
+     * the saved terminal levels rather than from zero initial conditions. The
+     * supplied differencer must have the same order as this model's spec.
+     *
+     * @param differencer The restored streaming differencer
+     */
+    void restoreDifferencer(const ag::util::StreamingDifferencer& differencer) {
+        differencer_ = differencer;
+    }
+
+    /**
      * @brief Get the ARIMA-GARCH specification for this model.
      * @return The ARIMA-GARCH specification
      */

--- a/include/ag/models/composite/ArimaGarchModel.hpp
+++ b/include/ag/models/composite/ArimaGarchModel.hpp
@@ -5,6 +5,7 @@
 #include "ag/models/arima/ArimaState.hpp"
 #include "ag/models/garch/GarchModel.hpp"
 #include "ag/models/garch/GarchState.hpp"
+#include "ag/util/Differencing.hpp"
 
 #include <cstddef>
 
@@ -54,6 +55,15 @@ struct ArimaGarchOutput {
  *
  * The update() method processes a single new observation, updates both states,
  * and returns μ_t and h_t for that observation.
+ *
+ * Differencing (d > 0): update() consumes raw level observations and
+ * differences them internally (Δ^d) before running the ARMA/GARCH recursion,
+ * which therefore operates on the stationary differenced series exactly as the
+ * fit does. The first d observations only prime the differencing pipeline (no
+ * innovation is produced). The conditional mean returned by update() is
+ * re-integrated to the original level scale, and the Forecaster integrates
+ * forecasts back to levels using the model's differencing anchors (see
+ * getDifferencer()).
  */
 class ArimaGarchModel {
 public:
@@ -85,17 +95,16 @@ public:
     /**
      * @brief Predict conditional mean and variance without updating state.
      *
-     * This method computes the one-step-ahead predictions μ_t and h_t using
-     * only information available up to time t-1, without updating the internal
-     * state. This is the correct method for computing diagnostic residuals,
-     * as it avoids look-ahead bias.
+     * Computes the one-step-ahead predictions using only information available
+     * up to time t-1, without updating the internal state.
      *
-     * For diagnostic purposes, use this method followed by manual state updates:
-     * 1. Call predict() to get μ_t and h_t
-     * 2. Compute residual ε_t = y_t - μ_t
-     * 3. Manually update state using the observation and residual
+     * Note on scale: the returned mean is on the differenced (stationary) scale
+     * the recursion operates on. For a level-scale mean (and diagnostic
+     * residuals), use update(), which differences/integrates internally; for
+     * level forecasts use the Forecaster, which integrates predict-style
+     * forecasts back to levels.
      *
-     * @return ArimaGarchOutput containing μ_t and h_t predictions
+     * @return ArimaGarchOutput containing the differenced-scale μ_t and h_t
      */
     [[nodiscard]] ArimaGarchOutput predict() const;
 
@@ -150,13 +159,25 @@ public:
      */
     [[nodiscard]] const garch::GarchState& getGarchState() const noexcept { return var_state_; }
 
+    /**
+     * @brief Get the differencing state (anchors) for d > 0 models.
+     *
+     * The Forecaster copies this to integrate differenced-scale forecasts back
+     * to the original level scale. For d == 0 it is an identity differencer.
+     * @return Reference to the streaming differencer
+     */
+    [[nodiscard]] const ag::util::StreamingDifferencer& getDifferencer() const noexcept {
+        return differencer_;
+    }
+
 private:
-    ag::models::ArimaGarchSpec spec_;  // Model specification
-    ArimaGarchParameters params_;      // Model parameters (fitted coefficients)
-    arima::ArimaModel arima_model_;    // ARIMA model instance
-    garch::GarchModel garch_model_;    // GARCH model instance
-    arima::ArimaState mean_state_;     // State for ARIMA recursion
-    garch::GarchState var_state_;      // State for GARCH recursion
+    ag::models::ArimaGarchSpec spec_;             // Model specification
+    ArimaGarchParameters params_;                 // Model parameters (fitted coefficients)
+    arima::ArimaModel arima_model_;               // ARIMA model instance
+    garch::GarchModel garch_model_;               // GARCH model instance
+    arima::ArimaState mean_state_;                // State for ARIMA recursion (differenced scale)
+    garch::GarchState var_state_;                 // State for GARCH recursion
+    ag::util::StreamingDifferencer differencer_;  // Δ^d / integration anchors
 
     /**
      * @brief Compute conditional mean for the current observation.

--- a/include/ag/util/Differencing.hpp
+++ b/include/ag/util/Differencing.hpp
@@ -80,6 +80,28 @@ public:
      */
     [[nodiscard]] int order() const noexcept { return d_; }
 
+    /**
+     * @brief The current integration anchors (most recent k-th order
+     *        differences, k = 0..d-1). Empty for d == 0.
+     */
+    [[nodiscard]] const std::vector<double>& anchors() const noexcept { return last_; }
+
+    /**
+     * @brief Number of raw observations consumed by difference().
+     */
+    [[nodiscard]] std::size_t observationCount() const noexcept { return count_; }
+
+    /**
+     * @brief Restore the anchors and observation count (e.g. when deserializing
+     *        a fitted model) so integration continues from the saved terminal
+     *        levels rather than from zero initial conditions.
+     *
+     * @param anchors The d most recent lower-order differences (size must == d)
+     * @param observation_count Number of raw observations previously consumed
+     * @throws std::invalid_argument if anchors.size() != order()
+     */
+    void restore(const std::vector<double>& anchors, std::size_t observation_count);
+
 private:
     int d_;                     // Differencing order
     std::vector<double> last_;  // last_[k] = most recent k-th order difference (k = 0..d-1)

--- a/include/ag/util/Differencing.hpp
+++ b/include/ag/util/Differencing.hpp
@@ -23,4 +23,67 @@ namespace ag::util {
  */
 [[nodiscard]] std::vector<double> differenceSeries(const double* data, std::size_t size, int d);
 
+/**
+ * @brief Streaming d-th order differencing with the inverse (integration).
+ *
+ * Maintains the last value of each lower-order difference so that a series of
+ * raw levels can be differenced one observation at a time, and a series of
+ * d-th order differences can be integrated back to levels one step at a time.
+ * This is the single source of truth for the differencing/integration the
+ * composite ARIMA-GARCH model and forecaster need for d > 0.
+ *
+ * Forward (difference): the first @c d observations only prime the pipeline —
+ * a d-th order difference is not defined until @c d+1 raw values have been
+ * seen, so difference() returns false for those. Afterwards it returns the
+ * d-th difference w_t = Δ^d y_t.
+ *
+ * Inverse (integrate): reconstructs a level from a d-th order difference using
+ * the current anchors, advancing them. A freshly constructed differencer has
+ * zero anchors, which integrates a difference series under zero initial
+ * conditions (a plain d-fold cumulative sum). The forecaster instead copies
+ * the model's primed differencer so integration continues from the real
+ * terminal levels.
+ *
+ * For d == 0 both operations are the identity.
+ */
+class StreamingDifferencer {
+public:
+    /**
+     * @brief Construct a differencer of the given order.
+     * @param d Differencing order (must be >= 0)
+     * @throws std::invalid_argument if d < 0
+     */
+    explicit StreamingDifferencer(int d);
+
+    /**
+     * @brief Feed one raw level and obtain its d-th order difference.
+     * @param level The new raw observation
+     * @param[out] differenced Set to Δ^d of the level when available
+     * @return true if a d-th difference was produced, false while priming
+     */
+    bool difference(double level, double& differenced);
+
+    /**
+     * @brief Integrate a d-th order difference back to a level, advancing anchors.
+     * @param differenced A d-th order difference (e.g. a forecast on the differenced scale)
+     * @return The reconstructed level
+     */
+    double integrate(double differenced);
+
+    /**
+     * @brief Whether enough observations have been seen to produce differences.
+     */
+    [[nodiscard]] bool primed() const noexcept;
+
+    /**
+     * @brief The differencing order.
+     */
+    [[nodiscard]] int order() const noexcept { return d_; }
+
+private:
+    int d_;                     // Differencing order
+    std::vector<double> last_;  // last_[k] = most recent k-th order difference (k = 0..d-1)
+    std::size_t count_ = 0;     // Number of raw observations seen by difference()
+};
+
 }  // namespace ag::util

--- a/src/diagnostics/Residuals.cpp
+++ b/src/diagnostics/Residuals.cpp
@@ -22,25 +22,34 @@ ResidualSeries computeResiduals(const ag::models::ArimaGarchSpec& spec,
     // Create the ARIMA-GARCH model (this validates parameters)
     ag::models::composite::ArimaGarchModel model(spec, params);
 
+    // The first d observations only prime the differencing pipeline and yield
+    // no innovation, so residuals exist for size - d observations (matching the
+    // likelihood, which works on the differenced series).
+    const std::size_t d = static_cast<std::size_t>(spec.arimaSpec.d);
+
     // Allocate output vectors
     ResidualSeries result;
-    result.eps_t.reserve(size);
-    result.h_t.reserve(size);
-    result.std_eps_t.reserve(size);
+    const std::size_t n_resid = (size > d) ? (size - d) : 0;
+    result.eps_t.reserve(n_resid);
+    result.h_t.reserve(n_resid);
+    result.std_eps_t.reserve(n_resid);
 
-    // Filter each observation through the model
+    // Filter each observation through the d-aware model. update() computes the
+    // conditional mean from past information only (then advances the state), so
+    // eps_t = y_t - mu_t carries no look-ahead bias and is the differenced-scale
+    // innovation.
     for (std::size_t t = 0; t < size; ++t) {
-        // Step 1: Predict conditional mean and variance using only past information
-        auto output = model.predict();
+        auto output = model.update(data[t]);
 
-        // Step 2: Compute residual: eps_t = y_t - mu_t
+        // Skip the priming observations (no innovation defined).
+        if (t < d) {
+            continue;
+        }
+
         double eps_t = data[t] - output.mu_t;
-
-        // Step 3: Get conditional variance: h_t
         double h_t = output.h_t;
 
-        // Step 4: Compute standardized residual: std_eps_t = eps_t / sqrt(h_t)
-        // h_t should always be > 0 for valid GARCH parameters
+        // h_t should always be > 0 for valid GARCH parameters.
         if (h_t <= 0.0) {
             throw std::runtime_error("Invalid conditional variance h_t <= 0 detected");
         }
@@ -51,24 +60,9 @@ ResidualSeries computeResiduals(const ag::models::ArimaGarchSpec& spec,
             throw std::runtime_error("Non-finite value detected in residual computation");
         }
 
-        // Store results
         result.eps_t.push_back(eps_t);
         result.h_t.push_back(h_t);
         result.std_eps_t.push_back(std_eps_t);
-
-        // Step 5: Manually update model state for next iteration
-        // Get references to the state objects (non-const via const_cast since we need to update)
-        auto& mean_state = const_cast<ag::models::arima::ArimaState&>(model.getArimaState());
-        auto& var_state = const_cast<ag::models::garch::GarchState&>(model.getGarchState());
-
-        // Update ARIMA state with current observation and residual
-        mean_state.update(data[t], eps_t);
-
-        // Update GARCH state with current variance and squared residual
-        if (!spec.garchSpec.isNull()) {
-            double eps_squared = eps_t * eps_t;
-            var_state.update(h_t, eps_squared);
-        }
     }
 
     return result;

--- a/src/forecasting/Forecaster.cpp
+++ b/src/forecasting/Forecaster.cpp
@@ -1,5 +1,6 @@
 #include "ag/forecasting/Forecaster.hpp"
 
+#include "ag/util/Differencing.hpp"
 #include "ag/util/NumericConstants.hpp"
 
 #include <algorithm>
@@ -36,23 +37,30 @@ ForecastResult Forecaster::forecast(int horizon) const {
     std::vector<double> var_history = garch_state.getVarianceHistory();
     std::vector<double> sq_res_history = garch_state.getSquaredResidualHistory();
 
+    // Differencing/integration anchors at the end of the data. The ARMA
+    // recursion forecasts on the differenced scale; we integrate each forecast
+    // back to the original level scale. A copy is used so integration over the
+    // horizon does not mutate the model. For d == 0 this is the identity.
+    ag::util::StreamingDifferencer integrator = model_.getDifferencer();
+
     // Iterate over the forecast horizon
     for (int h = 0; h < horizon; ++h) {
-        // Step 1: Forecast mean for step h+1
-        double mean_forecast = forecastMeanOneStep(obs_history, res_history);
-        result.mean_forecasts[h] = mean_forecast;
+        // Step 1: Forecast the mean on the differenced scale, then integrate to
+        // the original level scale.
+        double diff_mean_forecast = forecastMeanOneStep(obs_history, res_history);
+        result.mean_forecasts[h] = integrator.integrate(diff_mean_forecast);
 
         // Step 2: Forecast variance for step h+1
         double var_forecast = forecastVarianceOneStep(var_history, sq_res_history);
         result.variance_forecasts[h] = var_forecast;
 
-        // Step 3: Update observation history for next iteration
-        // Shift left and add new forecast (oldest removed)
+        // Step 3: Update observation history for next iteration on the
+        // differenced scale (oldest removed).
         if (spec.arimaSpec.p > 0) {
             for (int i = 0; i < spec.arimaSpec.p - 1; ++i) {
                 obs_history[i] = obs_history[i + 1];
             }
-            obs_history[spec.arimaSpec.p - 1] = mean_forecast;
+            obs_history[spec.arimaSpec.p - 1] = diff_mean_forecast;
         }
 
         // Step 4: Update residual history for next iteration

--- a/src/io/Json.cpp
+++ b/src/io/Json.cpp
@@ -93,6 +93,14 @@ nlohmann::json JsonWriter::toJson(const models::composite::ArimaGarchModel& mode
                                      {"garch", toJson(model.getGarchParams())}};
     j["state"] = nlohmann::json{{"arima", toJson(model.getArimaState())},
                                 {"garch", toJson(model.getGarchState())}};
+
+    // Differencing anchors (d > 0). Needed so a reloaded model integrates
+    // forecasts from the saved terminal levels rather than from zero.
+    const auto& differencer = model.getDifferencer();
+    j["state"]["differencer"] =
+        nlohmann::json{{"order", differencer.order()},
+                       {"anchors", differencer.anchors()},
+                       {"observation_count", differencer.observationCount()}};
     return j;
 }
 
@@ -381,6 +389,26 @@ JsonReader::loadModel(const std::filesystem::path& filepath) {
             }
 
             model.restoreState(*arima_state_result, *garch_state_result);
+
+            // Restore the differencing anchors so d > 0 models integrate
+            // forecasts from the saved terminal levels. Files written before
+            // this block existed simply keep the constructor's fresh (zero)
+            // anchors.
+            if (state_json.contains("differencer")) {
+                const auto& diff_json = state_json.at("differencer");
+                int order = diff_json.at("order").get<int>();
+                if (order != spec.arimaSpec.d) {
+                    return unexpected<JsonError>({"Differencer order mismatch: expected " +
+                                                  std::to_string(spec.arimaSpec.d) + ", got " +
+                                                  std::to_string(order)});
+                }
+                auto anchors = diff_json.at("anchors").get<std::vector<double>>();
+                auto observation_count = diff_json.at("observation_count").get<std::size_t>();
+
+                ag::util::StreamingDifferencer differencer(order);
+                differencer.restore(anchors, observation_count);
+                model.restoreDifferencer(differencer);
+            }
         }
 
         return model;

--- a/src/models/composite/ArimaGarchModel.cpp
+++ b/src/models/composite/ArimaGarchModel.cpp
@@ -11,8 +11,11 @@ namespace ag::models::composite {
 ArimaGarchModel::ArimaGarchModel(const ag::models::ArimaGarchSpec& spec,
                                  const ArimaGarchParameters& params)
     : spec_(spec), params_(params), arima_model_(spec.arimaSpec), garch_model_(spec.garchSpec),
-      mean_state_(spec.arimaSpec.p, spec.arimaSpec.d, spec.arimaSpec.q),
-      var_state_(spec.garchSpec.p, spec.garchSpec.q) {
+      // The ARMA recursion operates on the already-differenced series, so the
+      // mean state carries no differencing of its own (d = 0); differencing is
+      // owned by differencer_ below.
+      mean_state_(spec.arimaSpec.p, 0, spec.arimaSpec.q),
+      var_state_(spec.garchSpec.p, spec.garchSpec.q), differencer_(spec.arimaSpec.d) {
     // Validate specifications
     spec.arimaSpec.validate();
     spec.garchSpec.validate();
@@ -50,26 +53,37 @@ ArimaGarchModel::ArimaGarchModel(const ag::models::ArimaGarchSpec& spec,
 }
 
 ArimaGarchOutput ArimaGarchModel::update(double y_t) {
-    // Step 1: Compute conditional mean using ARIMA model
-    double mu_t = computeConditionalMean();
+    // Step 0: Difference the raw level. The ARMA/GARCH recursion runs on the
+    // differenced (stationary) series w_t = Δ^d y_t, matching the fit. While
+    // the differencing pipeline is priming (the first d observations) there is
+    // no innovation yet: just consume the level and report the current state.
+    double w_t = y_t;
+    if (!differencer_.difference(y_t, w_t)) {
+        double h_t = computeConditionalVariance();
+        return ArimaGarchOutput{y_t, h_t};
+    }
 
-    // Step 2: Compute residual
-    double eps_t = y_t - mu_t;
+    // Step 1: Conditional mean on the differenced scale (μ_w).
+    double mu_w = computeConditionalMean();
 
-    // Step 3: Compute conditional variance
+    // Step 2: Innovation on the differenced scale.
+    double eps_t = w_t - mu_w;
+
+    // Step 3: Conditional variance.
     double h_t = computeConditionalVariance();
 
-    // Step 4: Update ARIMA state
-    mean_state_.update(y_t, eps_t);
+    // Step 4: Update the ARIMA state with the differenced observation.
+    mean_state_.update(w_t, eps_t);
 
-    // Step 5: Update GARCH state (only if GARCH component exists)
+    // Step 5: Update GARCH state (only if a GARCH component exists).
     if (!spec_.garchSpec.isNull()) {
         double eps_squared = eps_t * eps_t;
         var_state_.update(h_t, eps_squared);
     }
 
-    // Return output
-    return ArimaGarchOutput{mu_t, h_t};
+    // The conditional mean on the original level scale satisfies
+    // y_t - mu_level = eps_t, so re-integrate by mu_level = y_t - eps_t.
+    return ArimaGarchOutput{y_t - eps_t, h_t};
 }
 
 ArimaGarchOutput ArimaGarchModel::predict() const {

--- a/src/simulation/ArimaGarchSimulator.cpp
+++ b/src/simulation/ArimaGarchSimulator.cpp
@@ -1,5 +1,7 @@
 #include "ag/simulation/ArimaGarchSimulator.hpp"
 
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/util/Differencing.hpp"
 #include "ag/util/NumericConstants.hpp"
 
 #include <cmath>
@@ -61,8 +63,16 @@ SimulationResult ArimaGarchSimulator::simulate(int length, unsigned int seed,
     // Create innovations generator
     Innovations innovations(seed);
 
-    // Create model instance for this simulation
-    ag::models::composite::ArimaGarchModel model(spec_, params_);
+    // The ARMA/GARCH recursion generates the stationary (differenced) process.
+    // Build a d = 0 model for that recursion and integrate the simulated path
+    // back to the level scale afterwards (Δ^d inverse, zero initial
+    // conditions). For d == 0 the integrator is the identity, so behavior is
+    // unchanged.
+    ag::models::ArimaSpec stationary_arima(spec_.arimaSpec.p, 0, spec_.arimaSpec.q);
+    ag::models::ArimaGarchSpec stationary_spec(stationary_arima, spec_.garchSpec);
+    ag::models::composite::ArimaGarchModel model(stationary_spec, params_);
+
+    ag::util::StreamingDifferencer integrator(spec_.arimaSpec.d);
 
     // Simulate path
     for (int t = 0; t < length; ++t) {
@@ -80,15 +90,17 @@ SimulationResult ArimaGarchSimulator::simulate(int length, unsigned int seed,
         const double mu_t = pred.mu_t;
         const double h_t = std::max(pred.h_t, ag::util::MIN_VARIANCE);
 
-        // Generate return: y_t = μ_t + sqrt(h_t) * z_t
-        double y_t = mu_t + std::sqrt(h_t) * z_t;
+        // Generate the differenced-scale value w_t = μ_t + sqrt(h_t) * z_t,
+        // then integrate to the level scale for the reported return.
+        double w_t = mu_t + std::sqrt(h_t) * z_t;
+        double y_t = integrator.integrate(w_t);
 
         // Store results
         result.returns[t] = y_t;
         result.volatilities[t] = std::sqrt(h_t);
 
-        // Update model state with the generated observation
-        model.update(y_t);
+        // Advance the stationary recursion with the differenced value.
+        model.update(w_t);
     }
 
     return result;

--- a/src/util/Differencing.cpp
+++ b/src/util/Differencing.cpp
@@ -94,4 +94,14 @@ bool StreamingDifferencer::primed() const noexcept {
     return count_ >= static_cast<std::size_t>(d_);
 }
 
+void StreamingDifferencer::restore(const std::vector<double>& anchors,
+                                   std::size_t observation_count) {
+    if (anchors.size() != static_cast<std::size_t>(d_)) {
+        throw std::invalid_argument(
+            "StreamingDifferencer::restore: anchor count must equal differencing order");
+    }
+    last_ = anchors;
+    count_ = observation_count;
+}
+
 }  // namespace ag::util

--- a/src/util/Differencing.cpp
+++ b/src/util/Differencing.cpp
@@ -33,4 +33,65 @@ std::vector<double> differenceSeries(const double* data, std::size_t size, int d
     return result;
 }
 
+StreamingDifferencer::StreamingDifferencer(int d) : d_(d) {
+    if (d < 0) {
+        throw std::invalid_argument("StreamingDifferencer: d must be >= 0");
+    }
+    last_.assign(static_cast<std::size_t>(d), 0.0);
+}
+
+bool StreamingDifferencer::difference(double level, double& differenced) {
+    if (d_ == 0) {
+        differenced = level;
+        return true;
+    }
+
+    // cur[k] is the k-th order difference of the current observation. cur[k]
+    // is computable only once we have a previous (k-1)-th order difference,
+    // i.e. after at least k prior observations.
+    std::vector<double> cur(static_cast<std::size_t>(d_) + 1);
+    cur[0] = level;
+    for (int k = 1; k <= d_; ++k) {
+        if (count_ < static_cast<std::size_t>(k)) {
+            // Still priming: store the orders we could compute and bail out.
+            for (int j = 0; j < k; ++j) {
+                last_[static_cast<std::size_t>(j)] = cur[static_cast<std::size_t>(j)];
+            }
+            ++count_;
+            return false;
+        }
+        cur[static_cast<std::size_t>(k)] =
+            cur[static_cast<std::size_t>(k - 1)] - last_[static_cast<std::size_t>(k - 1)];
+    }
+
+    // Fully primed: advance the anchors for orders 0..d-1 and emit Δ^d.
+    for (int j = 0; j < d_; ++j) {
+        last_[static_cast<std::size_t>(j)] = cur[static_cast<std::size_t>(j)];
+    }
+    ++count_;
+    differenced = cur[static_cast<std::size_t>(d_)];
+    return true;
+}
+
+double StreamingDifferencer::integrate(double differenced) {
+    if (d_ == 0) {
+        return differenced;
+    }
+
+    std::vector<double> cur(static_cast<std::size_t>(d_) + 1);
+    cur[static_cast<std::size_t>(d_)] = differenced;
+    for (int k = d_ - 1; k >= 0; --k) {
+        cur[static_cast<std::size_t>(k)] =
+            last_[static_cast<std::size_t>(k)] + cur[static_cast<std::size_t>(k + 1)];
+    }
+    for (int k = 0; k < d_; ++k) {
+        last_[static_cast<std::size_t>(k)] = cur[static_cast<std::size_t>(k)];
+    }
+    return cur[0];
+}
+
+bool StreamingDifferencer::primed() const noexcept {
+    return count_ >= static_cast<std::size_t>(d_);
+}
+
 }  // namespace ag::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,13 @@ add_executable(test_models_composite
 target_link_libraries(test_models_composite PRIVATE arimagarch)
 add_test(NAME test_models_composite COMMAND test_models_composite)
 
+add_executable(test_models_differencing
+    unit/test_models_differencing.cpp
+    unit/test_framework.cpp
+)
+target_link_libraries(test_models_differencing PRIVATE arimagarch)
+add_test(NAME test_models_differencing COMMAND test_models_differencing)
+
 # Estimation tests
 add_executable(test_estimation_parameters
     unit/test_estimation_parameters.cpp

--- a/tests/unit/test_io_json.cpp
+++ b/tests/unit/test_io_json.cpp
@@ -352,6 +352,47 @@ TEST(json_model_state_roundtrip_and_forecast) {
     std::filesystem::remove(model_file);
 }
 
+// For an integrated (d > 0) model the differencing anchors must survive the
+// JSON round-trip, so a reloaded model forecasts on the level scale identically
+// to the in-process model rather than integrating from zero.
+TEST(json_model_d1_state_roundtrip_and_forecast) {
+    auto model_file = std::filesystem::temp_directory_path() / "test_model_d1_roundtrip.json";
+
+    ArimaGarchSpec spec(1, 1, 0, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.arima_params.intercept = 0.1;
+    params.arima_params.ar_coef[0] = 0.4;
+    params.garch_params.omega = 0.02;
+    params.garch_params.alpha_coef[0] = 0.1;
+    params.garch_params.beta_coef[0] = 0.85;
+
+    ArimaGarchModel original_model(spec, params);
+    std::vector<double> levels = {10.0, 11.0, 13.0, 16.0, 20.0, 25.0, 31.0};
+    for (double y : levels) {
+        original_model.update(y);
+    }
+
+    auto save_result = JsonWriter::saveModel(model_file, original_model);
+    REQUIRE(save_result.has_value());
+    auto load_result = JsonReader::loadModel(model_file);
+    REQUIRE(load_result.has_value());
+    const auto& loaded_model = *load_result;
+
+    ag::forecasting::Forecaster original_forecaster(original_model);
+    ag::forecasting::Forecaster loaded_forecaster(loaded_model);
+    auto original_fc = original_forecaster.forecast(4);
+    auto loaded_fc = loaded_forecaster.forecast(4);
+
+    for (size_t h = 0; h < original_fc.mean_forecasts.size(); ++h) {
+        REQUIRE(approx_equal(loaded_fc.mean_forecasts[h], original_fc.mean_forecasts[h]));
+    }
+    // Sanity: forecasts are on the level scale (near the last level ~31), not
+    // integrated from zero.
+    REQUIRE(loaded_fc.mean_forecasts[0] > 25.0);
+
+    std::filesystem::remove(model_file);
+}
+
 // Test error handling for invalid JSON
 TEST(json_invalid_spec_handling) {
     nlohmann::json invalid_json = {{"p", -1}, {"d", 0}, {"q", 1}};

--- a/tests/unit/test_models_differencing.cpp
+++ b/tests/unit/test_models_differencing.cpp
@@ -1,0 +1,216 @@
+#include "ag/api/Engine.hpp"
+#include "ag/diagnostics/Residuals.hpp"
+#include "ag/forecasting/Forecaster.hpp"
+#include "ag/models/ArimaGarchSpec.hpp"
+#include "ag/models/composite/ArimaGarchModel.hpp"
+#include "ag/simulation/ArimaGarchSimulator.hpp"
+#include "ag/util/Differencing.hpp"
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include "test_framework.hpp"
+
+using ag::models::ArimaGarchSpec;
+using ag::models::composite::ArimaGarchModel;
+using ag::models::composite::ArimaGarchParameters;
+using ag::util::StreamingDifferencer;
+
+// ============================================================================
+// StreamingDifferencer unit tests
+// ============================================================================
+
+// d == 0 is the identity in both directions.
+TEST(streaming_differencer_order_zero_identity) {
+    StreamingDifferencer diff(0);
+    double w = 0.0;
+    REQUIRE(diff.difference(3.5, w));
+    REQUIRE_APPROX(w, 3.5, 1e-12);
+    REQUIRE_APPROX(diff.integrate(2.0), 2.0, 1e-12);
+}
+
+// First difference: priming consumes the first observation, then Δy is emitted.
+TEST(streaming_differencer_first_difference) {
+    StreamingDifferencer diff(1);
+    double w = 0.0;
+
+    REQUIRE(!diff.difference(10.0, w));  // priming
+    REQUIRE(diff.difference(11.0, w));
+    REQUIRE_APPROX(w, 1.0, 1e-12);
+    REQUIRE(diff.difference(13.0, w));
+    REQUIRE_APPROX(w, 2.0, 1e-12);
+}
+
+// Second differencing: two observations prime the pipeline, then Δ²y is
+// emitted. For {1,2,4,8,16} the second differences are 1, 2, 4.
+TEST(streaming_differencer_second_difference) {
+    StreamingDifferencer diff(2);
+    std::vector<double> levels = {1.0, 2.0, 4.0, 8.0, 16.0};
+    std::vector<double> emitted;
+    for (double level : levels) {
+        double w = 0.0;
+        if (diff.difference(level, w)) {
+            emitted.push_back(w);
+        }
+    }
+    REQUIRE(emitted.size() == 3);
+    REQUIRE_APPROX(emitted[0], 1.0, 1e-12);
+    REQUIRE_APPROX(emitted[1], 2.0, 1e-12);
+    REQUIRE_APPROX(emitted[2], 4.0, 1e-12);
+}
+
+// Integrating from zero anchors is the d-fold cumulative sum.
+TEST(streaming_differencer_integrate_is_cumulative_sum) {
+    StreamingDifferencer inv1(1);
+    REQUIRE_APPROX(inv1.integrate(2.0), 2.0, 1e-12);
+    REQUIRE_APPROX(inv1.integrate(3.0), 5.0, 1e-12);
+    REQUIRE_APPROX(inv1.integrate(-1.0), 4.0, 1e-12);
+
+    // Second-order: integrate twice-cumulatively. Feeding 1,1,1 yields the
+    // partial sums of partial sums: 1, 3, 6.
+    StreamingDifferencer inv2(2);
+    REQUIRE_APPROX(inv2.integrate(1.0), 1.0, 1e-12);
+    REQUIRE_APPROX(inv2.integrate(1.0), 3.0, 1e-12);
+    REQUIRE_APPROX(inv2.integrate(1.0), 6.0, 1e-12);
+}
+
+// ============================================================================
+// d-aware model + forecaster: deterministic level forecasts
+// ============================================================================
+
+// ARIMA(1,1,0)+GARCH(1,1): hand-computed one-, two-, three-step level
+// forecasts. The mean path is independent of the GARCH parameters.
+TEST(arima_d1_level_forecast_matches_hand_calc) {
+    ArimaGarchSpec spec(1, 1, 0, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.arima_params.intercept = 0.1;
+    params.arima_params.ar_coef[0] = 0.5;
+    params.garch_params.omega = 0.01;
+    params.garch_params.alpha_coef[0] = 0.1;
+    params.garch_params.beta_coef[0] = 0.8;
+
+    ArimaGarchModel model(spec, params);
+    std::vector<double> levels = {10.0, 11.0, 13.0, 16.0, 20.0};
+    for (double y : levels) {
+        model.update(y);
+    }
+
+    ag::forecasting::Forecaster forecaster(model);
+    auto fc = forecaster.forecast(3);
+
+    // w_T = 20 - 16 = 4
+    // mu_w1 = 0.1 + 0.5*4 = 2.1   -> level1 = 20 + 2.1 = 22.1
+    // mu_w2 = 0.1 + 0.5*2.1 = 1.15 -> level2 = 22.1 + 1.15 = 23.25
+    // mu_w3 = 0.1 + 0.5*1.15 = 0.675 -> level3 = 23.25 + 0.675 = 23.925
+    REQUIRE_APPROX(fc.mean_forecasts[0], 22.1, 1e-9);
+    REQUIRE_APPROX(fc.mean_forecasts[1], 23.25, 1e-9);
+    REQUIRE_APPROX(fc.mean_forecasts[2], 23.925, 1e-9);
+
+    // Level forecasts must be near the last level, not near the differenced
+    // scale (~0): a regression guard against the un-integrated bug.
+    REQUIRE(fc.mean_forecasts[0] > 15.0);
+}
+
+// ============================================================================
+// d-aware diagnostics: residual count matches the likelihood (size - d)
+// ============================================================================
+
+TEST(diagnostics_residual_count_matches_size_minus_d) {
+    for (int d = 0; d <= 2; ++d) {
+        ArimaGarchSpec spec(1, d, 0, 1, 1);
+        ArimaGarchParameters params(spec);
+        params.arima_params.intercept = 0.0;
+        params.arima_params.ar_coef[0] = 0.3;
+        params.garch_params.omega = 0.05;
+        params.garch_params.alpha_coef[0] = 0.1;
+        params.garch_params.beta_coef[0] = 0.8;
+
+        std::vector<double> data(40);
+        double level = 0.0;
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            level += 0.1 * static_cast<double>(i % 3) - 0.05;
+            data[i] = level + 0.01 * static_cast<double>(i);
+        }
+
+        auto residuals = ag::diagnostics::computeResiduals(spec, params, data.data(), data.size());
+        REQUIRE(residuals.eps_t.size() == data.size() - static_cast<std::size_t>(d));
+    }
+}
+
+// ============================================================================
+// d-aware simulation: the d=1 path is the integral of the d=0 path
+// ============================================================================
+
+TEST(simulate_d1_is_integral_of_d0) {
+    ArimaGarchSpec spec_d0(1, 0, 0, 1, 1);
+    ArimaGarchSpec spec_d1(1, 1, 0, 1, 1);
+
+    ArimaGarchParameters params0(spec_d0);
+    params0.arima_params.intercept = 0.02;
+    params0.arima_params.ar_coef[0] = 0.4;
+    params0.garch_params.omega = 0.01;
+    params0.garch_params.alpha_coef[0] = 0.1;
+    params0.garch_params.beta_coef[0] = 0.85;
+
+    ArimaGarchParameters params1(spec_d1);
+    params1.arima_params = params0.arima_params;
+    params1.garch_params = params0.garch_params;
+
+    const int length = 50;
+    const unsigned int seed = 7;
+
+    ag::simulation::ArimaGarchSimulator sim0(spec_d0, params0);
+    ag::simulation::ArimaGarchSimulator sim1(spec_d1, params1);
+    auto r0 = sim0.simulate(length, seed);
+    auto r1 = sim1.simulate(length, seed);
+
+    // Identical params/seed => identical differenced draws; the d=1 returns are
+    // the cumulative sum of the d=0 returns.
+    REQUIRE_APPROX(r1.returns[0], r0.returns[0], 1e-9);
+    for (int t = 1; t < length; ++t) {
+        REQUIRE_APPROX(r1.returns[t] - r1.returns[t - 1], r0.returns[t], 1e-9);
+    }
+}
+
+// End-to-end on the CLI default path (select defaults to --max-d 1): fit an
+// ARIMA(1,1,0)+GARCH(1,1) with drift and confirm the forecast is on the level
+// scale (near the last observed level), not collapsed to the differenced-scale
+// intercept (~0) as the un-integrated bug produced.
+TEST(engine_fit_forecast_d1_is_level_scale) {
+    std::mt19937 gen(11);
+    std::normal_distribution<double> nd(0.0, 1.0);
+
+    std::vector<double> data(150);
+    double w_prev = 0.0;
+    double level = 0.0;
+    for (std::size_t i = 0; i < data.size(); ++i) {
+        double w = 0.3 * w_prev + nd(gen) + 2.0;  // AR(1) differences with drift
+        w_prev = w - 2.0;
+        level += w;
+        data[i] = level;
+    }
+
+    REQUIRE(data.back() > 100.0);  // strongly trending, far from zero
+
+    ag::api::Engine engine;
+    ArimaGarchSpec spec(1, 1, 0, 1, 1);
+    auto fit = engine.fit(data, spec, false);
+    REQUIRE(fit.has_value());
+    REQUIRE(fit.value().summary.converged);
+
+    auto fc = engine.forecast(*fit.value().model, 5);
+    REQUIRE(fc.has_value());
+    REQUIRE(fc.value().mean_forecasts.size() == 5);
+
+    // One-step forecast continues from the last level (differenced mean is
+    // small); the old bug would land near 0, far below data.back().
+    double f0 = fc.value().mean_forecasts[0];
+    REQUIRE(std::isfinite(f0));
+    REQUIRE(std::abs(f0 - data.back()) < 25.0);
+}
+
+int main() {
+    report_test_results("ARIMA Differencing (d > 0)");
+    return get_test_result();
+}


### PR DESCRIPTION
## Summary

Fixes #128 (P0, Critical).

Fitting differenced the series correctly, but the composite model, forecaster, diagnostics, and Engine warm-up all operated on **raw levels** and never re-integrated. For any `d > 0`, differenced-scale coefficients were applied to undifferenced levels and forecasts were never integrated back to the level scale — silently wrong results on the default user path (`select` defaults to `--max-d 1`), with the entire `d > 0` path untested. (For `p > 0, d > 0` the model constructor actually threw `Insufficient data after differencing` while initializing state on dummy data.)

## Approach — composite model as the single d-aware source of truth

- **`ag::util::StreamingDifferencer`** (new): streaming `Δ^d` differencing and its inverse (integration) via maintained lower-order anchors. The first `d` observations prime the pipeline; `d == 0` is the identity in both directions.
- **`ArimaGarchModel::update()`** now consumes **raw levels**: differences internally, runs the ARMA/GARCH recursion on the stationary differenced series (exactly as the fit does), then re-integrates the conditional mean to the level scale (`mu_level = y_t − ε_t`). The mean state is constructed with `d = 0` (it holds the differenced series); the model owns the differencer and exposes anchors via `getDifferencer()`.
- **`Forecaster`** integrates each differenced-scale mean forecast back to a level using a copy of the model's differencer; the AR history is advanced on the differenced scale.
- **`Residuals`** filters through the d-aware `update()` and skips the first `d` priming steps, so it emits `size − d` residuals (matching the likelihood) and no longer needs `const_cast` (bonus toward #139).
- **Simulator** generates the stationary process with a `d = 0` model and integrates the path to levels, so `simulate()` produces level series for `d > 0` (unchanged for `d == 0`).
- **Engine warm-up and CrossValidation need no change**: feeding raw levels through the now d-aware `update()` and integrating in the Forecaster makes them correct automatically.

## Tests (new `test_models_differencing` suite)
- `StreamingDifferencer` difference & integrate, d=1 and d=2 (incl. cumulative-sum property).
- Deterministic ARIMA(1,1,0) one/two/three-step **level** forecasts vs a hand-computed reference (exact).
- Diagnostics residual count `== size − d` for d=0,1,2.
- `simulate` d=1 equals the cumulative sum of d=0 (same seed/params).
- Engine `fit → forecast` end-to-end on a trending ARIMA(1,1,0), asserting the 1-step forecast tracks the last level (the old bug landed near the ~0 differenced-scale intercept).

## Scope notes
- **Variance forecasts** remain the per-step GARCH conditional variance `h_{t+h}` (the innovation variance), not the integrated level-forecast-error variance — out of scope here and a reasonable separate enhancement.
- **State serialization for d>0:** this PR doesn't change what `update()` stores. Persisting the differencer's integration anchors across save/load is a small follow-up needed for `d > 0` `ag forecast -m model.json` (coordinates with #129, now merged); flagging rather than expanding scope.

## Verification
- Full build green; `ctest` 38/38 pass (new suite + all existing, d=0 paths unchanged).
- `clang-format --dry-run --Werror` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_