### PR TITLE
Never select Student-t on a negative likelihood ratio (#134)

### DIFF
--- a/src/selection/DistributionSelector.cpp
+++ b/src/selection/DistributionSelector.cpp
@@ -114,8 +114,16 @@ compareDistributions(const ag::models::ArimaGarchSpec& spec,
 
     // Step 4: Likelihood ratio test
     // H0: Gaussian (restricted), H1: Student-t (unrestricted)
-    // LR = 2 * (LL_t - LL_n) ~ chi^2(1) under H0
+    // LR = 2 * (LL_t - LL_n) ~ chi^2(1) under H0.
+    // The Student-t fit uses an estimated df that does not exactly nest the
+    // Gaussian at finite df, so student_t_ll < normal_ll (a negative LR) is
+    // possible. A negative LR means "no evidence for the richer model"; clamp
+    // it to 0 so the chi-square tail reports p = 1 rather than leaking a
+    // spurious low p-value, and so the reported statistic is never negative.
     double lr_stat = 2.0 * (student_t_ll - normal_ll);
+    if (lr_stat < 0.0) {
+        lr_stat = 0.0;
+    }
     double lr_p_value = ag::stats::chi_square_ccdf(lr_stat, 1.0);
 
     // Step 5: Information criteria
@@ -131,8 +139,11 @@ compareDistributions(const ag::models::ArimaGarchSpec& spec,
     // Step 6: Compute kurtosis
     double kurt = ag::stats::kurtosis(residuals.std_eps_t);
 
-    // Step 7: Make recommendation
-    bool prefer_student_t = (lr_p_value < 0.05) || ((student_t_bic < normal_bic) && (kurt > 1.0));
+    // Step 7: Make recommendation. Only ever prefer Student-t when it actually
+    // fits at least as well as Normal (student_t_ll >= normal_ll); a worse fit
+    // must never be selected regardless of the IC/kurtosis heuristic.
+    bool prefer_student_t = (student_t_ll >= normal_ll) &&
+                            ((lr_p_value < 0.05) || ((student_t_bic < normal_bic) && (kurt > 1.0)));
 
     return DistributionTestResult{.prefer_student_t = prefer_student_t,
                                   .normal_ll = normal_ll,

--- a/tests/unit/test_selection_distribution_selector.cpp
+++ b/tests/unit/test_selection_distribution_selector.cpp
@@ -138,8 +138,40 @@ TEST(compare_distributions_simple_model) {
     // Student-t log-likelihood could be less than Gaussian due to
     // suboptimal df estimation via grid search
     // Just verify calculations are consistent
-    double calculated_lr = 2.0 * (result.student_t_ll - result.normal_ll);
+    // lr_statistic is clamped to >= 0 (a negative LR means no evidence for the
+    // richer model).
+    double calculated_lr = std::max(0.0, 2.0 * (result.student_t_ll - result.normal_ll));
     REQUIRE_APPROX(result.lr_statistic, calculated_lr, 1e-8);
+    REQUIRE(result.lr_statistic >= 0.0);
+}
+
+// A worse Student-t fit (student_t_ll < normal_ll) must never select Student-t,
+// and must report p = 1 with a clamped (zero) LR statistic — not a spurious
+// "significant" p = 0. Regression test for the negative-LR guard.
+TEST(compare_distributions_negative_lr_not_significant) {
+    // Light-tailed (platykurtic) data: a uniform ramp gives standardized
+    // residuals with no heavy tails, so the estimated-df Student-t fit is no
+    // better than Normal.
+    // omega/(1 - alpha - beta) = 1, so standardized residuals are ~unit
+    // variance; a uniform ramp over ~[-sqrt(3), sqrt(3)] is then platykurtic
+    // and the heavier-tailed Student-t fits strictly worse than Normal.
+    ArimaGarchSpec spec(0, 0, 0, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.garch_params.omega = 0.05;
+    params.garch_params.alpha_coef = {0.05};
+    params.garch_params.beta_coef = {0.9};
+
+    std::vector<double> data;
+    for (int i = 0; i < 400; ++i) {
+        data.push_back(-1.732 + 2.0 * 1.732 * (i % 40) / 39.0);
+    }
+
+    DistributionTestResult result = compareDistributions(spec, params, data.data(), data.size());
+
+    REQUIRE(result.student_t_ll < result.normal_ll);  // confirm we exercise the branch
+    REQUIRE(!result.prefer_student_t);
+    REQUIRE_APPROX(result.lr_statistic, 0.0, 1e-12);
+    REQUIRE_APPROX(result.lr_p_value, 1.0, 1e-12);
 }
 
 // Test with null data


### PR DESCRIPTION
## Summary

Fixes #134.

The Student-t fit uses an *estimated* df that doesn't exactly nest the Gaussian at finite df, so `student_t_ll < normal_ll` (a negative LR) is possible — e.g. on light-tailed (platykurtic) standardized residuals. The reported `lr_statistic` could then be negative, and the `prefer_student_t` heuristic could still select Student-t when it fits strictly worse than Normal.

## Changes
- **Clamp `lr_stat` to `>= 0`** before the chi-square tail. A negative LR is "no evidence for the richer model" → p = 1 (not a spurious low value), and the reported statistic is never negative.
- **Guard `prefer_student_t` with `student_t_ll >= normal_ll`** so a worse fit is never selected regardless of the IC/kurtosis heuristic.
- Updated the existing `lr_statistic` assertion to the clamped value; added `compare_distributions_negative_lr_not_significant` on a unit-variance light-tailed fixture (verified `student_t_ll < normal_ll`) asserting `prefer_student_t == false`, `lr_statistic == 0`, `p == 1`.

## Note
With #132 already merged, `lr_p_value` is computed via `chi_square_ccdf` directly (so a negative LR no longer produces the literal `p = 0` the issue described); this PR makes the intended behavior explicit and robust, fixes the negative reported statistic, and—critically—closes the second selection path (`bic`/`kurt` branch) that the original `p`-value reasoning didn't cover.

## Verification
- Full build green; `ctest` 38/38; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_