### PR TITLE
Fix CSV header detection with leading blank line and error line numbers (#136)

### DIFF
--- a/src/io/CsvReader.cpp
+++ b/src/io/CsvReader.cpp
@@ -113,10 +113,14 @@ expected<data::TimeSeries, CsvReadError>
 CsvReader::read_from_string(std::string_view csv_content, const CsvReaderOptions& options) {
     std::vector<std::string> header_row;
     std::vector<std::vector<std::string>> all_rows;
+    // Physical (1-based) line number of each stored data row, so error messages
+    // point at the real line even when blank lines are skipped or interspersed.
+    std::vector<std::size_t> row_line_numbers;
     std::string content_str{csv_content};
     std::istringstream stream{content_str};
     std::string line;
     std::size_t line_number = 0;
+    bool header_captured = false;
 
     // First pass: read all rows
     while (std::getline(stream, line)) {
@@ -137,13 +141,17 @@ CsvReader::read_from_string(std::string_view csv_content, const CsvReaderOptions
             continue;
         }
 
-        // Store header if configured
-        if (line_number == 1 && options.has_header) {
+        // Store the header on the first non-empty line (not necessarily the
+        // first physical line — a leading blank line must not be treated as
+        // the header).
+        if (options.has_header && !header_captured) {
             header_row = columns;
+            header_captured = true;
             continue;
         }
 
         all_rows.push_back(columns);
+        row_line_numbers.push_back(line_number);
     }
 
     // Check if we have any data rows
@@ -202,8 +210,8 @@ CsvReader::read_from_string(std::string_view csv_content, const CsvReaderOptions
                 get_column_label(detected_value_column, options.has_header, header_row);
             return unexpected(CsvReadError{
                 "Value column " + col_label + " (index " + std::to_string(detected_value_column) +
-                ") out of range on line " + std::to_string(i + 1 + (options.has_header ? 1 : 0)) +
-                " (found " + std::to_string(row.size()) + " columns)"});
+                ") out of range on line " + std::to_string(row_line_numbers[i]) + " (found " +
+                std::to_string(row.size()) + " columns)"});
         }
 
         // Parse value (may be empty/null)
@@ -212,8 +220,8 @@ CsvReader::read_from_string(std::string_view csv_content, const CsvReaderOptions
             std::string col_label =
                 get_column_label(detected_value_column, options.has_header, header_row);
             return unexpected(CsvReadError{"Failed to parse value in " + col_label + " on line " +
-                                           std::to_string(i + 1 + (options.has_header ? 1 : 0)) +
-                                           ": " + value_result.error().message});
+                                           std::to_string(row_line_numbers[i]) + ": " +
+                                           value_result.error().message});
         }
 
         values.push_back(*value_result);
@@ -250,7 +258,7 @@ CsvReader::read_from_string(std::string_view csv_content, const CsvReaderOptions
                 get_column_label(detected_value_column, options.has_header, header_row);
             return unexpected(CsvReadError{
                 "Empty or null value found in " + col_label + " on line " +
-                std::to_string(i + 1 + (options.has_header ? 1 : 0)) +
+                std::to_string(row_line_numbers[i]) +
                 ". Only leading and trailing empty values are automatically trimmed."});
         }
     }

--- a/tests/unit/test_io_csv.cpp
+++ b/tests/unit/test_io_csv.cpp
@@ -99,6 +99,37 @@ TEST(csv_read_from_string_with_header) {
     REQUIRE_APPROX(ts[2], 1.8, 1e-10);
 }
 
+// A leading blank line must not consume the header slot: the header is the
+// first non-empty line. Regression test for #136.
+TEST(csv_read_leading_blank_line_header) {
+    std::string csv_content = "\nValue\n1.5\n2.3\n";
+
+    CsvReaderOptions options;
+    options.has_header = true;
+
+    auto result = CsvReader::read_from_string(csv_content, options);
+    REQUIRE(result.has_value());
+
+    const auto& ts = *result;
+    REQUIRE(ts.size() == 2);
+    REQUIRE_APPROX(ts[0], 1.5, 1e-10);
+    REQUIRE_APPROX(ts[1], 2.3, 1e-10);
+}
+
+// Error messages report the physical line number even when blank lines are
+// interspersed. Regression test for #136.
+TEST(csv_read_error_line_number_with_blank_lines) {
+    // Physical lines: 1="1.0", 2=blank, 3="2.0", 4="bad", 5="3.0"
+    std::string csv_content = "1.0\n\n2.0\nbad\n3.0\n";
+
+    auto result = CsvReader::read_from_string(csv_content);
+    REQUIRE(!result.has_value());
+
+    const std::string& msg = result.error().message;
+    REQUIRE(msg.find("line 4") != std::string::npos);
+    REQUIRE(msg.find("line 3") == std::string::npos);
+}
+
 // Test reading from string with multiple columns
 TEST(csv_read_from_string_with_multiple_columns) {
     std::string csv_content = "Date,Value\n2020-01-01,1.5\n2020-01-02,2.3\n2020-01-03,1.8\n";


### PR DESCRIPTION
## Summary

Fixes #136.

`read_from_string` incremented `line_number` for every physical line (including blanks) and detected the header with `line_number == 1`. A leading blank line therefore consumed the header slot, so the real header was parsed as a **data row** (an auto-detect/parse error on otherwise-valid data). Separately, error messages computed the reported line as `i + 1 + has_header` over the *compacted* `all_rows` index, which drifts whenever blank lines are skipped.

## Changes
- Capture the header on the **first non-empty parsed line** via a `header_captured` flag instead of `line_number == 1`.
- Track each stored row's **physical (1-based) line number** (`row_line_numbers`) and use it in all three error messages instead of the compacted-index arithmetic.
- Tests: `csv_read_leading_blank_line_header` (header correctly identified) and `csv_read_error_line_number_with_blank_lines` (error reports the correct physical line `4`, not the drifted `3`).

## Verification
- Full build green; `ctest` 38/38; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_