### PR TITLE
Add minimal RFC-4180 quoted-field support to CsvReader (#141)

### DIFF
--- a/src/io/CsvReader.cpp
+++ b/src/io/CsvReader.cpp
@@ -21,20 +21,42 @@ std::string trim(const std::string& str) {
     return str.substr(start, end - start + 1);
 }
 
-// Helper function to split a line by delimiter
+// Helper function to split a line by delimiter with minimal RFC-4180 quoting.
+// A double-quoted field may contain the delimiter literally, and an escaped
+// quote ("") inside a quoted field denotes a single quote. Surrounding quotes
+// are stripped; fields are then trimmed (so quoted whitespace padding around a
+// numeric value is removed, matching the reader's numeric intent).
 std::vector<std::string> split_line(const std::string& line, char delimiter) {
     std::vector<std::string> result;
-    std::stringstream ss(line);
-    std::string item;
+    std::string field;
+    bool in_quotes = false;
 
-    while (std::getline(ss, item, delimiter)) {
-        result.push_back(trim(item));
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char c = line[i];
+        if (in_quotes) {
+            if (c == '"') {
+                if (i + 1 < line.size() && line[i + 1] == '"') {
+                    field.push_back('"');  // escaped quote ("")
+                    ++i;
+                } else {
+                    in_quotes = false;  // closing quote
+                }
+            } else {
+                field.push_back(c);
+            }
+        } else if (c == '"') {
+            in_quotes = true;
+        } else if (c == delimiter) {
+            result.push_back(trim(field));
+            field.clear();
+        } else {
+            field.push_back(c);
+        }
     }
 
-    // Handle trailing delimiter - if line ends with delimiter, add empty field
-    if (!line.empty() && line.back() == delimiter) {
-        result.push_back("");
-    }
+    // Final field (also yields the trailing empty field when the line ends with
+    // a delimiter).
+    result.push_back(trim(field));
 
     return result;
 }

--- a/tests/unit/test_io_csv.cpp
+++ b/tests/unit/test_io_csv.cpp
@@ -117,6 +117,50 @@ TEST(csv_read_from_string_with_multiple_columns) {
     REQUIRE_APPROX(ts[2], 1.8, 1e-10);
 }
 
+// Quoted numeric fields: surrounding quotes are stripped before parsing.
+// Regression test for #141.
+TEST(csv_read_quoted_numeric_fields) {
+    std::string csv_content = "\"1.5\"\n\"2.3\"\n\"1.8\"\n";
+
+    auto result = CsvReader::read_from_string(csv_content);
+    REQUIRE(result.has_value());
+
+    const auto& ts = *result;
+    REQUIRE(ts.size() == 3);
+    REQUIRE_APPROX(ts[0], 1.5, 1e-10);
+    REQUIRE_APPROX(ts[1], 2.3, 1e-10);
+    REQUIRE_APPROX(ts[2], 1.8, 1e-10);
+}
+
+// A delimiter inside a quoted field must not split the field, so column
+// alignment (and the numeric column) is preserved. Regression test for #141.
+TEST(csv_read_quoted_embedded_delimiter) {
+    // First column is a quoted label containing a comma; value is column 1.
+    std::string csv_content = "\"Jan, 2020\",1.5\n\"Feb, 2020\",2.3\n";
+
+    auto result = CsvReader::read_from_string(csv_content);
+    REQUIRE(result.has_value());
+
+    const auto& ts = *result;
+    REQUIRE(ts.size() == 2);
+    REQUIRE_APPROX(ts[0], 1.5, 1e-10);
+    REQUIRE_APPROX(ts[1], 2.3, 1e-10);
+}
+
+// Escaped quotes ("") inside a quoted field collapse to a single quote without
+// breaking field boundaries. Regression test for #141.
+TEST(csv_read_quoted_escaped_quotes) {
+    std::string csv_content = "\"a \"\"x\"\", b\",1.5\n\"c\",2.3\n";
+
+    auto result = CsvReader::read_from_string(csv_content);
+    REQUIRE(result.has_value());
+
+    const auto& ts = *result;
+    REQUIRE(ts.size() == 2);
+    REQUIRE_APPROX(ts[0], 1.5, 1e-10);
+    REQUIRE_APPROX(ts[1], 2.3, 1e-10);
+}
+
 // Test error handling: file not found
 TEST(csv_read_error_file_not_found) {
     std::filesystem::path bad_path = "/nonexistent/path/file.csv";


### PR DESCRIPTION
## Summary

Fixes #141.

`split_line` split purely on the delimiter via `getline`, so a quoted field containing the delimiter (e.g. a `"Jan, 2020"` label) was split across columns — shifting the auto-detected numeric column — and a quoted numeric value kept its surrounding quotes and failed numeric parsing.

## Changes
- Rewrote `split_line` with minimal RFC-4180 quoting: delimiters inside double quotes are literal, `""` inside a quoted field unescapes to a single `"`, and surrounding quotes are stripped. Fields are still trimmed (the reader's numeric intent). The final-field push also yields the trailing empty field, preserving prior trailing-delimiter behavior.
- Tests: quoted numeric fields, an embedded delimiter inside a quoted label (numeric column stays aligned), and escaped quotes. Existing unquoted fixtures unaffected.

## Verification
- Full build green; `ctest` 38/38; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_