### PR TITLE
Signal non-stationary unconditional variance with NaN, not a 0.0 sentinel (#142)

### DIFF
--- a/src/models/garch/GarchModel.cpp
+++ b/src/models/garch/GarchModel.cpp
@@ -3,6 +3,7 @@
 #include "ag/util/NumericConstants.hpp"
 
 #include <cmath>
+#include <limits>
 #include <numeric>
 #include <stdexcept>
 
@@ -53,17 +54,18 @@ bool GarchParameters::isStationary() const noexcept {
 }
 
 double GarchParameters::unconditionalVariance() const noexcept {
-    if (!isStationary()) {
-        return 0.0;
-    }
-
     double sum_alpha = std::accumulate(alpha_coef.begin(), alpha_coef.end(), 0.0);
     double sum_beta = std::accumulate(beta_coef.begin(), beta_coef.end(), 0.0);
     double denominator = 1.0 - sum_alpha - sum_beta;
 
-    // Guard against division by zero (though stationarity check should prevent this)
-    if (denominator <= 0.0) {
-        return 0.0;
+    // The unconditional variance does not exist at or above the stationarity
+    // boundary. A small margin keeps a near-singular denominator from producing
+    // an absurd value. Signal "not available" with NaN rather than the old 0.0
+    // sentinel, which conflated non-stationarity with the legitimate value 0 and
+    // forced GarchState to switch initialization on a 0.0 magic value.
+    constexpr double STATIONARITY_MARGIN = 1e-10;
+    if (denominator <= STATIONARITY_MARGIN) {
+        return std::numeric_limits<double>::quiet_NaN();
     }
 
     return omega / denominator;

--- a/src/models/garch/GarchState.cpp
+++ b/src/models/garch/GarchState.cpp
@@ -38,9 +38,12 @@ void GarchState::initialize(const double* residuals, std::size_t size,
         throw std::invalid_argument("Residuals size must be positive");
     }
 
-    // Determine initial variance (h_0)
-    if (unconditional_variance > 0.0) {
-        // Use provided unconditional variance (when stationary)
+    // Determine initial variance (h_0). Use the provided unconditional variance
+    // when it is a usable finite positive value; otherwise (non-stationary —
+    // signalled by NaN — or unspecified) fall back to the sample variance. The
+    // isfinite check, rather than a bare > 0.0, avoids relying on a 0.0 magic
+    // value and cleanly handles the NaN returned at the stationarity boundary.
+    if (std::isfinite(unconditional_variance) && unconditional_variance > 0.0) {
         initial_variance_ = unconditional_variance;
     } else {
         // Use sample variance of residuals as fallback

--- a/tests/unit/test_models_garch.cpp
+++ b/tests/unit/test_models_garch.cpp
@@ -4,8 +4,10 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <numeric>
 #include <random>
+#include <vector>
 
 #include "test_framework.hpp"
 
@@ -148,11 +150,39 @@ TEST(garch_params_unconditional_variance) {
     double expected_var = 0.1 / (1.0 - 0.15 - 0.75);
     REQUIRE_APPROX(params.unconditionalVariance(), expected_var, 1e-10);
 
-    // Non-stationary case
+    // Non-stationary case: the unconditional variance does not exist, signalled
+    // by NaN (not the old 0.0 sentinel, which conflated it with a real value).
     params.alpha_coef[0] = 0.5;
     params.beta_coef[0] = 0.5;
     REQUIRE(!params.isStationary());
-    REQUIRE_APPROX(params.unconditionalVariance(), 0.0, 1e-10);
+    REQUIRE(std::isnan(params.unconditionalVariance()));
+}
+
+// Near the IGARCH boundary (alpha + beta = 0.99) the unconditional variance is
+// finite and positive, and GarchState initializes h_0 from it (no 0.0 sentinel
+// / sample-variance flip). A NaN (non-stationary) falls back to a finite
+// positive sample variance. Regression test for #142.
+TEST(garch_unconditional_variance_near_igarch) {
+    GarchParameters params(1, 1);
+    params.omega = 0.02;
+    params.alpha_coef[0] = 0.09;
+    params.beta_coef[0] = 0.90;  // alpha + beta = 0.99
+
+    REQUIRE(params.isStationary());
+    double uv = params.unconditionalVariance();
+    REQUIRE(std::isfinite(uv));
+    REQUIRE(uv > 0.0);
+    REQUIRE_APPROX(uv, 0.02 / 0.01, 1e-9);
+
+    std::vector<double> residuals = {0.1, -0.2, 0.15, -0.05, 0.2, -0.1};
+    GarchState state(1, 1);
+    state.initialize(residuals.data(), residuals.size(), uv);
+    REQUIRE_APPROX(state.getInitialVariance(), uv, 1e-9);
+
+    GarchState state2(1, 1);
+    state2.initialize(residuals.data(), residuals.size(), std::numeric_limits<double>::quiet_NaN());
+    REQUIRE(std::isfinite(state2.getInitialVariance()));
+    REQUIRE(state2.getInitialVariance() > 0.0);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #142.

`unconditionalVariance()` returned `0.0` when not stationary, and `GarchState::initialize` silently fell back to the sample variance whenever it received a non-positive value. That conflated "non-stationary" with the legitimate value `0`, and forced the GARCH initialization to switch on a `0.0` magic value at the stationarity boundary.

## Changes
- `GarchParameters::unconditionalVariance()` returns **NaN** when the denominator `1 − Σα − Σβ` is at or below a small margin (non-stationary / near-singular), instead of the `0.0` sentinel.
- `GarchState::initialize` uses an `std::isfinite(uv) && uv > 0.0` check, so a NaN (or any unusable value) falls back to a finite positive sample variance without relying on `0.0`. **Stationary-model behavior is unchanged** (the finite positive unconditional variance is still used as `h_0`).
- `FitSummary`'s existing `> 0.0` guard already renders NaN as "does not exist (non-stationary GARCH)".
- Updated the non-stationary test to expect NaN; added `garch_unconditional_variance_near_igarch` (α+β=0.99): finite positive `h_0` used, and a NaN falls back to a positive sample variance.

## Note
The `α+β → 1⁻` region was already continuous (the old `0.0` only appeared *at/above* the boundary); this PR removes the sentinel conflation and the magic-value coupling, and the margin prevents a near-singular denominator from yielding an absurd `h_0`. Capping `h_0` against the sample variance was considered but rejected: the model constructor seeds `GarchState` with a dummy residual (sample variance `1.0`), so a cap there would corrupt `h_0` for legitimate stationary models.

## Verification
- Full build green; `ctest` 38/38; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_