### PR TITLE
Add ARIMA AR-stationarity / MA-invertibility checks (#140)

### DIFF
--- a/include/ag/models/arima/ArimaModel.hpp
+++ b/include/ag/models/arima/ArimaModel.hpp
@@ -25,6 +25,23 @@ struct ArimaParameters {
      * @param q Number of MA coefficients
      */
     ArimaParameters(int p, int q) : intercept(0.0), ar_coef(p, 0.0), ma_coef(q, 0.0) {}
+
+    /**
+     * @brief Whether the AR polynomial is stationary.
+     *
+     * True iff all roots of 1 − φ₁z − … − φₚzᵖ lie outside the unit circle.
+     * Uses the Schur-Cohn reflection-coefficient test (no root-finding). An
+     * empty AR part is trivially stationary.
+     */
+    [[nodiscard]] bool isStationary() const;
+
+    /**
+     * @brief Whether the MA polynomial is invertible.
+     *
+     * True iff all roots of 1 + θ₁z + … + θ_qz^q lie outside the unit circle.
+     * An empty MA part is trivially invertible.
+     */
+    [[nodiscard]] bool isInvertible() const;
 };
 
 /**

--- a/src/models/arima/ArimaModel.cpp
+++ b/src/models/arima/ArimaModel.cpp
@@ -1,8 +1,50 @@
 #include "ag/models/arima/ArimaModel.hpp"
 
+#include <cmath>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 namespace ag::models::arima {
+
+namespace {
+
+// Returns true iff all roots of the lag polynomial 1 - a_1 z - ... - a_p z^p
+// lie strictly outside the unit circle (i.e. the filter is minimum-phase).
+// Uses the Schur-Cohn / Levinson step-down recursion: the polynomial is stable
+// iff every reflection coefficient has magnitude < 1. No root-finding required.
+bool roots_outside_unit_circle(std::vector<double> a) {
+    while (!a.empty()) {
+        const std::size_t m = a.size();
+        const double k = a[m - 1];  // reflection coefficient at order m
+        if (std::abs(k) >= 1.0) {
+            return false;
+        }
+        const double denom = 1.0 - k * k;  // > 0 since |k| < 1
+        std::vector<double> next(m - 1);
+        for (std::size_t i = 0; i + 1 < m; ++i) {
+            next[i] = (a[i] + k * a[m - 2 - i]) / denom;
+        }
+        a = std::move(next);
+    }
+    return true;
+}
+
+}  // namespace
+
+bool ArimaParameters::isStationary() const {
+    // AR filter is 1 - phi_1 z - ... - phi_p z^p, so a_i = phi_i.
+    return roots_outside_unit_circle(ar_coef);
+}
+
+bool ArimaParameters::isInvertible() const {
+    // MA filter is 1 + theta_1 z + ... = 1 - (-theta_1) z - ..., so a_i = -theta_i.
+    std::vector<double> a(ma_coef.size());
+    for (std::size_t i = 0; i < ma_coef.size(); ++i) {
+        a[i] = -ma_coef[i];
+    }
+    return roots_outside_unit_circle(std::move(a));
+}
 
 ArimaModel::ArimaModel(const ag::models::ArimaSpec& spec) : spec_(spec) {
     spec.validate();

--- a/src/report/FitSummary.cpp
+++ b/src/report/FitSummary.cpp
@@ -52,6 +52,18 @@ std::string generateTextReport(const FitSummary& summary) {
         report += "\n";
     }
 
+    // AR stationarity / MA invertibility (reported; not enforced during fitting).
+    if (summary.spec.arimaSpec.p > 0) {
+        report += summary.parameters.arima_params.isStationary()
+                      ? "     AR stationarity:  stationary\n"
+                      : "     AR stationarity:  NON-STATIONARY (explosive AR roots)\n";
+    }
+    if (summary.spec.arimaSpec.q > 0) {
+        report += summary.parameters.arima_params.isInvertible()
+                      ? "     MA invertibility: invertible\n"
+                      : "     MA invertibility: NON-INVERTIBLE\n";
+    }
+
     report += "\n   GARCH:\n";
     report += fmt::format("     Omega:            {:.6f}\n", summary.parameters.garch_params.omega);
 

--- a/tests/unit/test_models_arima.cpp
+++ b/tests/unit/test_models_arima.cpp
@@ -398,6 +398,54 @@ TEST(arima_model_ar1_with_diff) {
     }
 }
 
+// AR-stationarity check (Schur-Cohn) flags stationary vs explosive AR sets.
+// Regression test for #140.
+TEST(arima_params_ar_stationarity) {
+    ArimaParameters p0(0, 0);
+    REQUIRE(p0.isStationary());  // no AR part is trivially stationary
+
+    ArimaParameters ar1(1, 0);
+    ar1.ar_coef = {0.5};
+    REQUIRE(ar1.isStationary());
+    ar1.ar_coef = {-0.99};
+    REQUIRE(ar1.isStationary());
+    ar1.ar_coef = {1.5};
+    REQUIRE(!ar1.isStationary());
+    ar1.ar_coef = {1.0};  // unit root
+    REQUIRE(!ar1.isStationary());
+
+    ArimaParameters ar2(2, 0);
+    ar2.ar_coef = {0.5, 0.2};  // inside the AR(2) stationarity triangle
+    REQUIRE(ar2.isStationary());
+    ar2.ar_coef = {0.6, -0.3};
+    REQUIRE(ar2.isStationary());
+    ar2.ar_coef = {0.5, 0.6};  // phi1 + phi2 > 1 -> non-stationary
+    REQUIRE(!ar2.isStationary());
+}
+
+// MA-invertibility check flags invertible vs non-invertible MA sets.
+// Regression test for #140.
+TEST(arima_params_ma_invertibility) {
+    ArimaParameters q0(0, 0);
+    REQUIRE(q0.isInvertible());  // no MA part is trivially invertible
+
+    ArimaParameters ma1(0, 1);
+    ma1.ma_coef = {0.5};
+    REQUIRE(ma1.isInvertible());
+    ma1.ma_coef = {-0.5};
+    REQUIRE(ma1.isInvertible());
+    ma1.ma_coef = {1.5};
+    REQUIRE(!ma1.isInvertible());
+    ma1.ma_coef = {1.0};  // root on the unit circle
+    REQUIRE(!ma1.isInvertible());
+
+    ArimaParameters ma2(0, 2);
+    ma2.ma_coef = {0.4, 0.2};
+    REQUIRE(ma2.isInvertible());
+    ma2.ma_coef = {0.3, 1.2};  // |theta_2| > 1 -> non-invertible
+    REQUIRE(!ma2.isInvertible());
+}
+
 int main() {
     report_test_results("ARIMA Models");
     return get_test_result();


### PR DESCRIPTION
## Summary

Fixes #140.

`GarchParameters` had `isStationary()` but `ArimaParameters` had no analogous AR-stationarity or MA-invertibility check, so explosive AR fits (`|φ| ≥ 1`) surfaced only later as `NaN`/`Inf` with no actionable diagnostic.

## Changes
- `ArimaParameters::isStationary()` and `isInvertible()` using the **Schur-Cohn / Levinson reflection-coefficient step-down** recursion (the polynomial is minimum-phase iff every reflection coefficient has magnitude < 1) — no root-finding or eigensolver dependency. Empty AR/MA parts are trivially stationary/invertible.
- Surfaced both in the fit summary (**reporting only**, not enforced as an optimizer constraint — per the issue's "introduce the check first, then consider enforcing" staging).
- Unit tests: AR(1)/AR(2) stationary vs explosive (incl. unit root and the `φ₁+φ₂>1` corner), MA(1)/MA(2) invertible vs non-invertible.

## Notes
- The FitSummary report test asserts substring presence, so the two added lines don't break it.
- Optimizer enforcement (penalizing explosive AR in `FitDriver`, mirroring GARCH) is deliberately left as a follow-up; this PR delivers the check + reporting.

## Verification
- Full build green; `ctest` 38/38; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_