### PR TITLE
Add an FFT path for ACF autocovariances (#138)

### DIFF
--- a/src/stats/ACF.cpp
+++ b/src/stats/ACF.cpp
@@ -2,10 +2,92 @@
 
 #include <algorithm>
 #include <cmath>
+#include <complex>
+#include <numbers>
 #include <numeric>
 #include <stdexcept>
 
 namespace ag::stats {
+
+namespace {
+
+// Below this length the direct O(n·max_lag) computation is used as a simple,
+// exact reference; at or above it the FFT path (O(n log n)) wins.
+constexpr std::size_t FFT_THRESHOLD = 64;
+
+// In-place iterative radix-2 Cooley-Tukey FFT. `a.size()` must be a power of 2.
+// `invert == true` computes the inverse transform (scaled by 1/n).
+void fft(std::vector<std::complex<double>>& a, bool invert) {
+    const std::size_t n = a.size();
+
+    // Bit-reversal permutation.
+    for (std::size_t i = 1, j = 0; i < n; ++i) {
+        std::size_t bit = n >> 1;
+        for (; (j & bit) != 0; bit >>= 1) {
+            j ^= bit;
+        }
+        j ^= bit;
+        if (i < j) {
+            std::swap(a[i], a[j]);
+        }
+    }
+
+    for (std::size_t len = 2; len <= n; len <<= 1) {
+        const double ang =
+            2.0 * std::numbers::pi / static_cast<double>(len) * (invert ? 1.0 : -1.0);
+        const std::complex<double> wlen(std::cos(ang), std::sin(ang));
+        for (std::size_t i = 0; i < n; i += len) {
+            std::complex<double> w(1.0, 0.0);
+            for (std::size_t k = 0; k < len / 2; ++k) {
+                const std::complex<double> u = a[i + k];
+                const std::complex<double> v = a[i + k + len / 2] * w;
+                a[i + k] = u + v;
+                a[i + k + len / 2] = u - v;
+                w *= wlen;
+            }
+        }
+    }
+
+    if (invert) {
+        for (auto& x : a) {
+            x /= static_cast<double>(n);
+        }
+    }
+}
+
+// Linear autocovariance sums Σ_i x_i·x_{i+k} for k = 0..max_lag, computed via
+// the Wiener-Khinchin theorem: zero-pad to length >= 2n-1 (a power of 2),
+// transform, take the power spectrum, and inverse-transform. The zero padding
+// makes the circular correlation equal the linear one, so the result matches
+// the direct sum to floating-point precision.
+std::vector<double> autocovariance_sums_fft(const std::vector<double>& demeaned,
+                                            std::size_t max_lag) {
+    const std::size_t n = demeaned.size();
+
+    std::size_t m = 1;
+    while (m < 2 * n) {
+        m <<= 1;
+    }
+
+    std::vector<std::complex<double>> fa(m, std::complex<double>(0.0, 0.0));
+    for (std::size_t i = 0; i < n; ++i) {
+        fa[i] = std::complex<double>(demeaned[i], 0.0);
+    }
+
+    fft(fa, false);
+    for (auto& v : fa) {
+        v = std::complex<double>(std::norm(v), 0.0);  // |X(f)|^2
+    }
+    fft(fa, true);
+
+    std::vector<double> gamma(max_lag + 1);
+    for (std::size_t k = 0; k <= max_lag; ++k) {
+        gamma[k] = fa[k].real();
+    }
+    return gamma;
+}
+
+}  // namespace
 
 double acf_at_lag(std::span<const double> data, std::size_t lag) {
     const std::size_t n = data.size();
@@ -67,11 +149,12 @@ std::vector<double> acf(std::span<const double> data, std::size_t max_lag) {
     double sum = std::accumulate(data.begin(), data.end(), 0.0);
     double mean = sum / static_cast<double>(n);
 
-    // Compute variance once (denominator for all lags)
+    // Demean once and reuse for the variance and every lag.
+    std::vector<double> demeaned(n);
     double variance = 0.0;
     for (std::size_t i = 0; i < n; ++i) {
-        double diff = data[i] - mean;
-        variance += diff * diff;
+        demeaned[i] = data[i] - mean;
+        variance += demeaned[i] * demeaned[i];
     }
 
     // Handle constant series - all ACF values are 0 except lag 0
@@ -86,11 +169,20 @@ std::vector<double> acf(std::span<const double> data, std::size_t max_lag) {
     // Lag 0: ACF is always 1.0
     result.push_back(1.0);
 
-    // Compute ACF for each lag
+    if (n >= FFT_THRESHOLD) {
+        // FFT path: O(n log n) autocovariances (Wiener-Khinchin).
+        std::vector<double> gamma = autocovariance_sums_fft(demeaned, max_lag);
+        for (std::size_t lag = 1; lag <= max_lag; ++lag) {
+            result.push_back(gamma[lag] / variance);
+        }
+        return result;
+    }
+
+    // Direct path (reference for small n): O(n·max_lag).
     for (std::size_t lag = 1; lag <= max_lag; ++lag) {
         double autocovariance = 0.0;
         for (std::size_t i = 0; i < n - lag; ++i) {
-            autocovariance += (data[i] - mean) * (data[i + lag] - mean);
+            autocovariance += demeaned[i] * demeaned[i + lag];
         }
         result.push_back(autocovariance / variance);
     }

--- a/tests/unit/test_stats_acf.cpp
+++ b/tests/unit/test_stats_acf.cpp
@@ -187,6 +187,45 @@ TEST(acf_result_size) {
     REQUIRE(result.size() == 6);
 }
 
+// For large n the FFT path must reproduce the direct O(n*lag) autocovariance
+// to floating-point precision. Regression test for #138.
+TEST(acf_fft_matches_direct_large_n) {
+    std::mt19937 gen(31337);
+    std::normal_distribution<double> dist(0.0, 1.0);
+
+    const std::size_t n = 300;  // >= FFT threshold, not a power of two
+    std::vector<double> data(n);
+    double prev = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        prev = 0.6 * prev + dist(gen);  // autocorrelated series
+        data[i] = prev;
+    }
+
+    const std::size_t max_lag = 20;
+    std::vector<double> fft_acf = ag::stats::acf(data, max_lag);
+
+    // Brute-force reference.
+    double mean = 0.0;
+    for (double v : data) {
+        mean += v;
+    }
+    mean /= static_cast<double>(n);
+    double var = 0.0;
+    for (double v : data) {
+        var += (v - mean) * (v - mean);
+    }
+
+    REQUIRE(fft_acf.size() == max_lag + 1);
+    REQUIRE_APPROX(fft_acf[0], 1.0, 1e-12);
+    for (std::size_t k = 1; k <= max_lag; ++k) {
+        double cov = 0.0;
+        for (std::size_t i = 0; i + k < n; ++i) {
+            cov += (data[i] - mean) * (data[i + k] - mean);
+        }
+        REQUIRE_APPROX(fft_acf[k], cov / var, 1e-9);
+    }
+}
+
 int main() {
     report_test_results("ACF Tests");
     return get_test_result();


### PR DESCRIPTION
## Summary

Fixes #138.

`acf` was O(n·max_lag) and is called once per bootstrap replicate by `ljung_box_test_bootstrap`, giving O(B·n·lags) overall, with the demeaned series recomputed for every lag.

## Changes
- Added an in-house iterative **radix-2 Cooley-Tukey FFT** (no new dependency — uses `<complex>`/`<numbers>`) and compute autocovariances via the **Wiener-Khinchin** theorem: zero-pad the demeaned series to a power of 2 ≥ 2n−1, forward-transform, take the power spectrum `|X(f)|²`, inverse-transform. The zero padding makes the circular correlation equal the linear one, so the result equals the direct sum to floating-point precision.
- `acf()` now **demeans once** and reuses it; for `n ≥ 64` it uses the O(n log n) FFT path and keeps the **direct O(n·max_lag) method as a reference for small n**. `acf_at_lag` (single lag) stays direct.
- Test asserts the FFT path matches a brute-force reference within 1e-9 on a large autocorrelated (non-power-of-two) series.

## Verification
- Full build green; `ctest` 38/38 — existing ACF/PACF/Ljung-Box (incl. bootstrap) suites confirm values are unchanged; `clang-format` clean.
- Complexity: bootstrap ACF work drops from O(B·n·lags) to O(B·n log n); `LjungBox`/`PACF`/`Bootstrap` benefit transparently since they call `acf`.

## Notes
- The threshold (64) keeps the exact, simple direct method for short series (where FFT setup isn't worth it) and as a correctness reference, per the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_