### PR TITLE
Enforce ARIMA AR-stationarity as an optimizer constraint (#158)

### DIFF
--- a/src/estimation/FitDriver.cpp
+++ b/src/estimation/FitDriver.cpp
@@ -93,6 +93,16 @@ std::optional<FitOutcome> runFit(const double* data, std::size_t n,
             return CONSTRAINT_PENALTY;
         }
 
+        // Enforce AR stationarity (mirrors the GARCH constraint below): steer
+        // the optimizer away from the explosive AR region, where the mean
+        // recursion diverges. A zero-order AR part is trivially stationary, so
+        // this is a no-op for those specs. MA invertibility is intentionally
+        // not enforced (a non-invertible MA has an observationally-equivalent
+        // invertible representation); it remains report-only.
+        if (!arima_p.isStationary()) {
+            return CONSTRAINT_PENALTY;
+        }
+
         if (!spec.garchSpec.isNull()) {
             if (!garch_p.isPositive() || !garch_p.isStationary()) {
                 return CONSTRAINT_PENALTY;

--- a/tests/unit/test_api_engine.cpp
+++ b/tests/unit/test_api_engine.cpp
@@ -57,6 +57,48 @@ TEST(engine_fit_basic) {
     REQUIRE(fit_result.value().summary.diagnostics.has_value());
 }
 
+// AR-stationarity is enforced during fitting (#158): a stationary AR(1) fit
+// converges and returns stationary coefficients.
+TEST(engine_fit_ar_stationarity_enforced) {
+    ArimaGarchSpec spec(1, 0, 0, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.arima_params.intercept = 0.0;
+    params.arima_params.ar_coef[0] = 0.6;
+    params.garch_params.omega = 0.05;
+    params.garch_params.alpha_coef[0] = 0.1;
+    params.garch_params.beta_coef[0] = 0.8;
+
+    ArimaGarchSimulator simulator(spec, params);
+    auto sim = simulator.simulate(500, 2024);
+
+    Engine engine;
+    auto fit = engine.fit(sim.returns, spec, false);
+    REQUIRE(fit.has_value());
+    REQUIRE(fit.value().summary.converged);
+    REQUIRE(fit.value().summary.parameters.arima_params.isStationary());
+}
+
+// Near the unit root (phi ~ 0.95) the AR-stationarity constraint must not break
+// convergence. Regression guard for #158.
+TEST(engine_fit_near_unit_root_converges) {
+    ArimaGarchSpec spec(1, 0, 0, 1, 1);
+    ArimaGarchParameters params(spec);
+    params.arima_params.intercept = 0.0;
+    params.arima_params.ar_coef[0] = 0.95;
+    params.garch_params.omega = 0.05;
+    params.garch_params.alpha_coef[0] = 0.1;
+    params.garch_params.beta_coef[0] = 0.8;
+
+    ArimaGarchSimulator simulator(spec, params);
+    auto sim = simulator.simulate(500, 99);
+
+    Engine engine;
+    auto fit = engine.fit(sim.returns, spec, false);
+    REQUIRE(fit.has_value());
+    REQUIRE(fit.value().summary.converged);
+    REQUIRE(fit.value().summary.parameters.arima_params.isStationary());
+}
+
 TEST(engine_fit_insufficient_data) {
     ArimaGarchSpec spec(1, 0, 1, 1, 1);
     std::vector<double> data = {1.0, 2.0, 3.0};  // Too few observations


### PR DESCRIPTION
## Summary

Fixes #158 (follow-up to #140).

`FitDriver::runFit`'s objective constrained the GARCH block (`isPositive() && isStationary()` → `CONSTRAINT_PENALTY`) but applied **no analogous constraint to the AR coefficients**. So the optimizer could wander into the explosive AR region — diverging residuals/variances that only surface later as `NaN`/`Inf` (now caught by the #131 guard as a non-converged failure) — and could return explosive AR coefficients even when a stationary fit exists.

## Changes
- **`src/estimation/FitDriver.cpp`**: the objective now returns `CONSTRAINT_PENALTY` when `arima_p.isStationary()` is false (the Schur-Cohn check added in #140), mirroring the existing GARCH constraint. A zero-order AR part is trivially stationary, so this is a no-op for those specs.
- **MA invertibility is intentionally *not* enforced** — a non-invertible MA has an observationally-equivalent invertible representation, so hard-rejecting it would needlessly fragment the search surface. It remains report-only.
- **Tests** (`test_api_engine.cpp`): a stationary AR(1) fit converges and reports stationary coefficients; a **near-unit-root (φ≈0.95)** fit still converges — the convergence regression guard the issue asked for.

## Design decisions (from the issue's open questions)
- **AR-only vs. MA too:** AR-only, per the above.
- **Hard penalty vs. soft barrier:** hard `CONSTRAINT_PENALTY`, matching the GARCH treatment for consistency; the near-unit-root test confirms Nelder–Mead with restarts still converges at the boundary.

## Verification
- Full build green; `ctest` 38/38 — existing estimation/selection suites confirm no convergence regression; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T

---
_Generated by [Claude Code](https://claude.ai/code/session_014awjRdur7BqDjBnEkwxx1T)_